### PR TITLE
allow insecure access to kubelet api

### DIFF
--- a/agent/platform.go
+++ b/agent/platform.go
@@ -34,6 +34,7 @@ func NewPlatform(ctx context.Context, ignoreContainer *regexp.Regexp) (platform.
 
 	case platform.Kubernetes:
 		useReadOnlyPort := true
+		insecureTLS := false
 		host, err := getEnvValue("MACKEREL_KUBERNETES_KUBELET_HOST")
 		if err != nil {
 			return nil, err
@@ -48,6 +49,10 @@ func NewPlatform(ctx context.Context, ignoreContainer *regexp.Regexp) (platform.
 			if err != nil {
 				port = kubelet.DefaultPort
 			}
+			_, err := getEnvValue("MACKEREL_KUBERNETES_KUBELET_INSECURE_TLS")
+			if err == nil {
+				insecureTLS = true
+			}
 		}
 		namespace, err := getEnvValue("MACKEREL_KUBERNETES_NAMESPACE")
 		if err != nil {
@@ -57,7 +62,7 @@ func NewPlatform(ctx context.Context, ignoreContainer *regexp.Regexp) (platform.
 		if err != nil {
 			return nil, err
 		}
-		return kubernetes.NewKubernetesPlatform(host, port, useReadOnlyPort, namespace, podName, ignoreContainer)
+		return kubernetes.NewKubernetesPlatform(host, port, useReadOnlyPort, insecureTLS, namespace, podName, ignoreContainer)
 
 	default:
 		return nil, errors.New("platform not specified")

--- a/agent/platform.go
+++ b/agent/platform.go
@@ -53,11 +53,11 @@ func NewPlatform(ctx context.Context, ignoreContainer *regexp.Regexp) (platform.
 		if err != nil {
 			return nil, err
 		}
-		name, err := getEnvValue("MACKEREL_KUBERNETES_POD_NAME")
+		podName, err := getEnvValue("MACKEREL_KUBERNETES_POD_NAME")
 		if err != nil {
 			return nil, err
 		}
-		return kubernetes.NewKubernetesPlatform(host, port, useReadOnlyPort, namespace, name, ignoreContainer)
+		return kubernetes.NewKubernetesPlatform(host, port, useReadOnlyPort, namespace, podName, ignoreContainer)
 
 	default:
 		return nil, errors.New("platform not specified")

--- a/platform/kubernetes/kubernetes.go
+++ b/platform/kubernetes/kubernetes.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"net/url"
 	"regexp"
 	"strings"
 	"time"
@@ -20,9 +21,8 @@ import (
 )
 
 var (
-	logger        = logging.GetLogger("kubernetes")
-	timeout       = 3 * time.Second
-	kubenetesName = "kubernetes"
+	logger  = logging.GetLogger("kubernetes")
+	timeout = 3 * time.Second
 
 	caCertificateFile = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 	tokenFile         = "/var/run/secrets/kubernetes.io/serviceaccount/token"
@@ -34,19 +34,15 @@ type kubernetesPlatform struct {
 
 // NewKubernetesPlatform creates a new Platform
 func NewKubernetesPlatform(kubeletHost, kubeletPort string, useReadOnlyPort, insecureTLS bool, namespace, podName string, ignoreContainer *regexp.Regexp) (platform.Platform, error) {
-	var rslv *resolver
 	var caCert, token []byte
 
-	baseURL := "http://" + net.JoinHostPort(kubeletHost, kubeletPort)
+	baseURL := &url.URL{
+		Scheme: "http",
+		Host:   net.JoinHostPort(kubeletHost, kubeletPort),
+	}
 
 	if !useReadOnlyPort {
-		baseURL = "https://" + net.JoinHostPort(kubenetesName, kubeletPort)
-
-		rslv = &resolver{
-			host:    kubenetesName,
-			port:    kubeletPort,
-			address: kubeletHost,
-		}
+		baseURL.Scheme = "https"
 
 		var err error
 
@@ -61,9 +57,16 @@ func NewKubernetesPlatform(kubeletHost, kubeletPort string, useReadOnlyPort, ins
 		}
 	}
 
-	httpClient := createHTTPClient(caCert, rslv, insecureTLS)
+	httpClient := createHTTPClient(caCert, insecureTLS)
 
-	c, err := kubelet.NewClient(httpClient, string(token), baseURL, namespace, podName, ignoreContainer)
+	c, err := kubelet.NewClient(
+		httpClient,
+		string(token),
+		baseURL.String(),
+		namespace,
+		podName,
+		ignoreContainer,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -104,11 +107,7 @@ func (p *kubernetesPlatform) StatusRunning(ctx context.Context) bool {
 	return strings.EqualFold("running", meta.Status.Phase)
 }
 
-type resolver struct {
-	host, port, address string
-}
-
-func createHTTPClient(caCert []byte, resolver *resolver, insecureTLS bool) *http.Client {
+func createHTTPClient(caCert []byte, insecureTLS bool) *http.Client {
 	// Copy from the definition of http.DefaultTransport.DialContext.
 	dialer := &net.Dialer{
 		Timeout:   30 * time.Second,
@@ -125,10 +124,6 @@ func createHTTPClient(caCert []byte, resolver *resolver, insecureTLS bool) *http
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
 	}
-	client := &http.Client{
-		Timeout:   timeout,
-		Transport: transport,
-	}
 
 	transport.TLSClientConfig = &tls.Config{
 		InsecureSkipVerify: insecureTLS,
@@ -140,22 +135,8 @@ func createHTTPClient(caCert []byte, resolver *resolver, insecureTLS bool) *http
 		transport.TLSClientConfig.RootCAs = certPool
 	}
 
-	if resolver != nil {
-		hostPort := net.JoinHostPort(resolver.host, resolver.port)
-		resolved := net.JoinHostPort(resolver.address, resolver.port)
-		transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
-			if addr == hostPort {
-				addr = resolved
-			}
-			return dialer.DialContext(ctx, network, addr)
-		}
-		transport.Dial = func(network, addr string) (net.Conn, error) {
-			if addr == hostPort {
-				addr = resolved
-			}
-			return dialer.Dial(network, addr)
-		}
+	return &http.Client{
+		Timeout:   timeout,
+		Transport: transport,
 	}
-
-	return client
 }

--- a/platform/kubernetes/kubernetes.go
+++ b/platform/kubernetes/kubernetes.go
@@ -33,7 +33,7 @@ type kubernetesPlatform struct {
 }
 
 // NewKubernetesPlatform creates a new Platform
-func NewKubernetesPlatform(kubeletHost, kubeletPort string, useReadOnlyPort bool, namespace, name string, ignoreContainer *regexp.Regexp) (platform.Platform, error) {
+func NewKubernetesPlatform(kubeletHost, kubeletPort string, useReadOnlyPort bool, namespace, podName string, ignoreContainer *regexp.Regexp) (platform.Platform, error) {
 	var rslv *resolver
 	var caCert, token []byte
 
@@ -63,7 +63,7 @@ func NewKubernetesPlatform(kubeletHost, kubeletPort string, useReadOnlyPort bool
 
 	httpClient := createHTTPClient(caCert, rslv)
 
-	c, err := kubelet.NewClient(httpClient, string(token), baseURL, namespace, name, ignoreContainer)
+	c, err := kubelet.NewClient(httpClient, string(token), baseURL, namespace, podName, ignoreContainer)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- skip verifying Kubelet CA certificates with `MACKEREL_KUBERNETES_KUBELET_INSECURE_TLS`.
- access kubelet api with host ip address.