### PR TITLE
Return callback not found error in mock clients

### DIFF
--- a/api/mock_client.go
+++ b/api/mock_client.go
@@ -36,12 +36,18 @@ func (c *MockClient) ApplyOption(opt MockClientOption) {
 	opt(c)
 }
 
+type errCallbackNotFound string
+
+func (err errCallbackNotFound) Error() string {
+	return string(err) + " callback not found"
+}
+
 // FindHost ...
 func (c *MockClient) FindHost(id string) (*mackerel.Host, error) {
 	if c.findHostCallback != nil {
 		return c.findHostCallback(id)
 	}
-	return nil, nil
+	return nil, errCallbackNotFound("FindHost")
 }
 
 // MockFindHost returns an option to set the callback of FindHost
@@ -56,7 +62,7 @@ func (c *MockClient) FindHosts(param *mackerel.FindHostsParam) ([]*mackerel.Host
 	if c.findHostsCallback != nil {
 		return c.findHostsCallback(param)
 	}
-	return nil, nil
+	return nil, errCallbackNotFound("FindHosts")
 }
 
 // MockFindHosts returns an option to set the callback of FindHosts
@@ -71,7 +77,7 @@ func (c *MockClient) CreateHost(param *mackerel.CreateHostParam) (string, error)
 	if c.createHostCallback != nil {
 		return c.createHostCallback(param)
 	}
-	return "", nil
+	return "", errCallbackNotFound("CreateHost")
 }
 
 // MockCreateHost returns an option to set the callback of CreateHost
@@ -86,7 +92,7 @@ func (c *MockClient) UpdateHost(hostID string, param *mackerel.UpdateHostParam) 
 	if c.updateHostCallback != nil {
 		return c.updateHostCallback(hostID, param)
 	}
-	return "", nil
+	return "", errCallbackNotFound("UpdateHost")
 }
 
 // MockUpdateHost returns an option to set the callback of UpdateHost
@@ -101,7 +107,7 @@ func (c *MockClient) UpdateHostStatus(hostID string, status string) error {
 	if c.updateHostStatusCallback != nil {
 		return c.updateHostStatusCallback(hostID, status)
 	}
-	return nil
+	return errCallbackNotFound("UpdateHostStatus")
 }
 
 // MockUpdateHostStatus returns an option to set the callback of UpdateHostStatus
@@ -116,7 +122,7 @@ func (c *MockClient) RetireHost(id string) error {
 	if c.retireHostCallback != nil {
 		return c.retireHostCallback(id)
 	}
-	return nil
+	return errCallbackNotFound("RetireHost")
 }
 
 // MockRetireHost returns an option to set the callback of RetireHost

--- a/platform/ecs/agent/mock_client.go
+++ b/platform/ecs/agent/mock_client.go
@@ -29,12 +29,18 @@ func (c *MockClient) ApplyOption(opt MockClientOption) {
 	opt(c)
 }
 
+type errCallbackNotFound string
+
+func (err errCallbackNotFound) Error() string {
+	return string(err) + " callback not found"
+}
+
 // GetInstanceMetadata ...
 func (c *MockClient) GetInstanceMetadata(ctx context.Context) (*ecsTypes.MetadataResponse, error) {
 	if c.getInstanceMetadataCallback != nil {
 		return c.getInstanceMetadataCallback(ctx)
 	}
-	return nil, nil
+	return nil, errCallbackNotFound("GetInstanceMetadata")
 }
 
 // MockGetInstanceMetadata returns an option to set the callback of GetInstanceMetadata
@@ -49,7 +55,7 @@ func (c *MockClient) GetTaskMetadataWithDockerID(ctx context.Context, dockerID s
 	if c.getTaskMetadataWithDockerIDCallback != nil {
 		return c.getTaskMetadataWithDockerIDCallback(ctx, dockerID)
 	}
-	return nil, nil
+	return nil, errCallbackNotFound("GetTaskMetadataWithDockerID")
 }
 
 // MockGetTaskMetadataWithDockerID returns an option to set the callback of GetTaskMetadataWithDockerID

--- a/platform/ecs/docker/mock_client.go
+++ b/platform/ecs/docker/mock_client.go
@@ -29,12 +29,18 @@ func (c *MockClient) ApplyOption(opt MockClientOption) {
 	opt(c)
 }
 
+type errCallbackNotFound string
+
+func (err errCallbackNotFound) Error() string {
+	return string(err) + " callback not found"
+}
+
 // GetContainerStats ...
 func (c *MockClient) GetContainerStats(ctx context.Context, id string) (*dockerTypes.StatsJSON, error) {
 	if c.getContainerStatsCallback != nil {
 		return c.getContainerStatsCallback(ctx, id)
 	}
-	return nil, nil
+	return nil, errCallbackNotFound("GetContainerStats")
 }
 
 // MockGetContainerStats returns an option to set the callback of GetContainerStats
@@ -49,7 +55,7 @@ func (c *MockClient) InspectContainer(ctx context.Context, id string) (*dockerTy
 	if c.inspectContainerCallback != nil {
 		return c.inspectContainerCallback(ctx, id)
 	}
-	return nil, nil
+	return nil, errCallbackNotFound("InspectContainer")
 }
 
 // MockInspectContainer returns an option to set the callback of InspectContainer

--- a/platform/ecs/task/task_test.go
+++ b/platform/ecs/task/task_test.go
@@ -343,6 +343,13 @@ func TestIgnoreContainer(t *testing.T) {
 				}, nil
 			},
 		),
+		agent.MockGetInstanceMetadata(
+			func(context.Context) (*ecsTypes.MetadataResponse, error) {
+				return &ecsTypes.MetadataResponse{
+					Cluster: "mackerel-container-agent",
+				}, nil
+			},
+		),
 	)
 
 	tests := []struct {

--- a/platform/ecsawsvpc/taskmetadata/mock_client.go
+++ b/platform/ecsawsvpc/taskmetadata/mock_client.go
@@ -30,12 +30,18 @@ func (c *MockClient) ApplyOption(opt MockClientOption) {
 	opt(c)
 }
 
+type errCallbackNotFound string
+
+func (err errCallbackNotFound) Error() string {
+	return string(err) + " callback not found"
+}
+
 // GetMetadata ...
 func (c *MockClient) GetMetadata(ctx context.Context) (*ecsTypes.TaskResponse, error) {
 	if c.getMetadataCallback != nil {
 		return c.getMetadataCallback(ctx)
 	}
-	return nil, nil
+	return nil, errCallbackNotFound("GetMetadata")
 }
 
 // MockGetMetadata returns an option to set the callback of GetMetadata
@@ -50,7 +56,7 @@ func (c *MockClient) GetStats(ctx context.Context) (map[string]*dockerTypes.Stat
 	if c.getStatsCallback != nil {
 		return c.getStatsCallback(ctx)
 	}
-	return nil, nil
+	return nil, errCallbackNotFound("GetStats")
 }
 
 // MockGetStats returns an option to set the callback of GetStats

--- a/platform/kubernetes/kubelet/mock_client.go
+++ b/platform/kubernetes/kubelet/mock_client.go
@@ -26,12 +26,18 @@ func (c *MockClient) ApplyOption(opt MockClientOption) {
 	opt(c)
 }
 
+type errCallbackNotFound string
+
+func (err errCallbackNotFound) Error() string {
+	return string(err) + " callback not found"
+}
+
 // GetPod ...
 func (c *MockClient) GetPod(ctx context.Context) (*Pod, error) {
 	if c.getPodCallback != nil {
 		return c.getPodCallback(ctx)
 	}
-	return nil, nil
+	return nil, errCallbackNotFound("GetPod")
 }
 
 // MockGetPod returns an option to set the callback of GetPod
@@ -46,7 +52,7 @@ func (c *MockClient) GetPodStats(ctx context.Context) (*PodStats, error) {
 	if c.getPodStatsCallback != nil {
 		return c.getPodStatsCallback(ctx)
 	}
-	return nil, nil
+	return nil, errCallbackNotFound("GetPodStats")
 }
 
 // MockGetPodStats returns an option to set the callback of GetPodStats
@@ -61,7 +67,7 @@ func (c *MockClient) GetSpec(ctx context.Context) (*MachineInfo, error) {
 	if c.getSpecCallback != nil {
 		return c.getSpecCallback(ctx)
 	}
-	return nil, nil
+	return nil, errCallbackNotFound("GetSpec")
 }
 
 // MockGetSpec returns an option to set the callback of GetSpec


### PR DESCRIPTION
Mock clients should report error when callback is not initialized by the tests.