### PR TITLE
Upgrade Mackerel::ReleaseUtils

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 BIN := mackerel-container-agent
 LDFLAGS := -ldflags="-extldflags \"-static\""
-VERSION = 0.0.2
+VERSION := 0.0.2
 REVISION := $(shell git rev-parse --short HEAD)
 
 .PHONY: all

--- a/script/cpanfile
+++ b/script/cpanfile
@@ -1,1 +1,1 @@
-requires 'Mackerel::ReleaseUtils', 'v0.2.3';
+requires 'Mackerel::ReleaseUtils', 'v0.2.4';


### PR DESCRIPTION
This pull request upgrades Mackerel::ReleaseUtils to v0.2.4. Also, simply-binded variable is preferred in Makefile.
Ref: https://github.com/mackerelio/Mackerel-ReleaseUtils/pull/4