### PR TITLE
Fix to get subgruop(cgroup) for the new ARN

### DIFF
--- a/platform/ecs/task/task.go
+++ b/platform/ecs/task/task.go
@@ -246,7 +246,7 @@ func (t *task) getTaskSubgroup() (string, error) {
 
 	memSs, ok := cg[memorySubsystem]
 	if !ok {
-		return "", fmt.Errorf("%s subsystem not exists", memorySubsystem)
+		return "", fmt.Errorf("%s subsystem does not exist", memorySubsystem)
 	}
 
 	// expect "/ecs/TASK_ID" or "/ecs/CLUSTER_NAME/TASK_ID"

--- a/platform/ecs/task/task.go
+++ b/platform/ecs/task/task.go
@@ -185,7 +185,7 @@ func getDockerID(proc procfs.Proc) (string, error) {
 		return "", errors.New("memory cgroup not exists")
 	}
 	parts := strings.Split(memCgroup.CgroupPath, string(os.PathSeparator))
-	if len(parts) != 4 || parts[1] != "ecs" {
+	if parts[1] != "ecs" {
 		return "", fmt.Errorf("faild to parse %s", memCgroup.CgroupPath)
 	}
 	return parts[len(parts)-1], nil

--- a/platform/ecs/task/task.go
+++ b/platform/ecs/task/task.go
@@ -186,7 +186,7 @@ func getDockerID(proc procfs.Proc) (string, error) {
 		return "", errors.New("memory cgroup not exists")
 	}
 	parts := strings.Split(memCgroup.CgroupPath, string(os.PathSeparator))
-	if parts[1] != "ecs" {
+	if len(parts) < 4 || parts[1] != "ecs" { // expect ["", "ecs", "task-id", "docker-id"] or ["", "ecs", "cluster-name", "task-id", "docker-id"]
 		return "", fmt.Errorf("failed to parse %s", memCgroup.CgroupPath)
 	}
 	return parts[len(parts)-1], nil

--- a/platform/ecs/task/task.go
+++ b/platform/ecs/task/task.go
@@ -186,7 +186,7 @@ func getDockerID(proc procfs.Proc) (string, error) {
 	}
 	parts := strings.Split(memCgroup.CgroupPath, string(os.PathSeparator))
 	if parts[1] != "ecs" {
-		return "", fmt.Errorf("faild to parse %s", memCgroup.CgroupPath)
+		return "", fmt.Errorf("failed to parse %s", memCgroup.CgroupPath)
 	}
 	return parts[len(parts)-1], nil
 }

--- a/platform/ecs/task/task.go
+++ b/platform/ecs/task/task.go
@@ -24,6 +24,7 @@ import (
 const (
 	taskArnPrefix   = "task/"
 	ecsSubgroupName = "ecs"
+	memorySubsystem = "memory"
 )
 
 // Task interface gets task metric values and metadata
@@ -180,7 +181,7 @@ func getDockerID(proc procfs.Proc) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	memCgroup := cgroup["memory"]
+	memCgroup := cgroup[memorySubsystem]
 	if memCgroup == nil {
 		return "", errors.New("memory cgroup not exists")
 	}

--- a/platform/ecs/task/task_test.go
+++ b/platform/ecs/task/task_test.go
@@ -99,7 +99,7 @@ var mockProc = procfs.NewMockProc(
 	procfs.MockCgroup(
 		func() (procfs.Cgroup, error) {
 			return procfs.Cgroup{
-				"memory": &procfs.CgroupLine{
+				memorySubsystem: &procfs.CgroupLine{
 					CgroupPath: "/ecs/e01d58a8-151b-40e8-bc01-22647b9ecfec/7e088b28bde202f19243853b0d20998a005984efa3d4b6c18e771fd149f86648",
 				},
 			}, nil
@@ -184,7 +184,7 @@ func TestDockerID(t *testing.T) {
 			procfs.MockCgroup(
 				func() (procfs.Cgroup, error) {
 					return procfs.Cgroup{
-						"memory": &procfs.CgroupLine{
+						memorySubsystem: &procfs.CgroupLine{
 							CgroupPath: tc.path,
 						},
 					}, nil
@@ -249,7 +249,7 @@ func TestMetadata(t *testing.T) {
 				procfs.MockCgroup(
 					func() (procfs.Cgroup, error) {
 						return procfs.Cgroup{
-							"memory": &procfs.CgroupLine{
+							memorySubsystem: &procfs.CgroupLine{
 								CgroupPath: "/ecs/task-id/docker-id",
 							},
 						}, nil
@@ -271,7 +271,7 @@ func TestMetadata(t *testing.T) {
 				procfs.MockCgroup(
 					func() (procfs.Cgroup, error) {
 						return procfs.Cgroup{
-							"memory": &procfs.CgroupLine{
+							memorySubsystem: &procfs.CgroupLine{
 								CgroupPath: "/ecs/cluster-name/task-id/docker-id-with-new-arn",
 							},
 						}, nil

--- a/platform/ecs/task/task_test.go
+++ b/platform/ecs/task/task_test.go
@@ -135,10 +135,18 @@ func TestDockerID(t *testing.T) {
 		{
 			cgroup: procfs.Cgroup{
 				"memory": &procfs.CgroupLine{
-					CgroupPath: "/ecs/e01d58a8-151b-40e8-bc01-22647b9ecfec/7e088b28bde202f19243853b0d20998a005984efa3d4b6c18e771fd149f86648",
+					CgroupPath: "/ecs/task-id/docker-id",
 				},
 			},
-			expected: "7e088b28bde202f19243853b0d20998a005984efa3d4b6c18e771fd149f86648",
+			expected: "docker-id",
+		},
+		{
+			cgroup: procfs.Cgroup{
+				"memory": &procfs.CgroupLine{
+					CgroupPath: "/ecs/cluster-name/task-id/docker-id",
+				},
+			},
+			expected: "docker-id",
 		},
 	}
 

--- a/platform/ecs/task/task_test.go
+++ b/platform/ecs/task/task_test.go
@@ -446,3 +446,39 @@ func TestIgnoreContainer(t *testing.T) {
 	}
 
 }
+
+func TestGetTaskSubGroup(t *testing.T) {
+	tests := []struct {
+		path     string
+		expected string
+	}{
+		{"/ecs/task-id/docker-id", "/ecs/task-id"},
+		{"/ecs/cluster-name/task-id/docker-id", "/ecs/cluster-name/task-id"},
+	}
+
+	for _, tc := range tests {
+		proc := procfs.NewMockProc(
+			procfs.MockCgroup(
+				func() (procfs.Cgroup, error) {
+					return procfs.Cgroup{
+						memorySubsystem: &procfs.CgroupLine{
+							CgroupPath: tc.path,
+						},
+					}, nil
+				},
+			),
+		)
+
+		tsk := &task{proc: proc}
+
+		got, err := tsk.getTaskSubgroup()
+		if err != nil {
+			t.Errorf("getTaskSubgroup() should not raise error: %v", err)
+		}
+
+		if got != tc.expected {
+			t.Errorf("getTaskSubgroup() expected %s containers, got %v containers", tc.expected, got)
+		}
+	}
+
+}

--- a/platform/ecs/task/task_test.go
+++ b/platform/ecs/task/task_test.go
@@ -154,24 +154,28 @@ var mockDockerClient = docker.NewMockClient(
 
 func TestDockerID(t *testing.T) {
 	tests := []struct {
-		cgroup   procfs.Cgroup
+		path     string
 		expected string
 	}{
 		{
-			cgroup: procfs.Cgroup{
-				"memory": &procfs.CgroupLine{
-					CgroupPath: "/ecs/task-id/docker-id",
-				},
-			},
+			path:     "/ecs/task-id/docker-id",
 			expected: "docker-id",
 		},
 		{
-			cgroup: procfs.Cgroup{
-				"memory": &procfs.CgroupLine{
-					CgroupPath: "/ecs/cluster-name/task-id/docker-id",
-				},
-			},
+			path:     "/ecs/cluster-name/task-id/docker-id",
 			expected: "docker-id",
+		},
+		{
+			path:     "/",
+			expected: "",
+		},
+		{
+			path:     "/ecs",
+			expected: "",
+		},
+		{
+			path:     "/ecs/task-id",
+			expected: "",
 		},
 	}
 
@@ -179,7 +183,11 @@ func TestDockerID(t *testing.T) {
 		mockProc := procfs.NewMockProc(
 			procfs.MockCgroup(
 				func() (procfs.Cgroup, error) {
-					return tc.cgroup, nil
+					return procfs.Cgroup{
+						"memory": &procfs.CgroupLine{
+							CgroupPath: tc.path,
+						},
+					}, nil
 				},
 			),
 		)


### PR DESCRIPTION
In a ECS task where the new ARN is opted-in, subgroups(cgroup) are changed.

* `current ARN`: /ecs/TASK_ID/DOCKER_ID
* `new ARN`: /ecs/CLUSTER_NAME/TASK_ID/DOCKER_ID

This pull request fix to this.

see. https://docs.aws.amazon.com/AmazonECS/latest/userguide/ecs-resource-ids.html