### PR TITLE
Release version 0.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.0.3 (2019-03-29)
+
+* Fix to get subgruop(cgroup) for the new ARN #13 (hayajo)
+
+
 ## 0.0.2 (2019-02-25)
 
 * check http reponse status code #4 (hayajo)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 BIN := mackerel-container-agent
-VERSION := 0.0.2
+VERSION := 0.0.3
 REVISION := $(shell git rev-parse --short HEAD)
 
 .PHONY: all


### PR DESCRIPTION
- Fix to get subgruop(cgroup) for the new ARN #13