### PR TITLE
Improve getting TaskID

### DIFF
--- a/platform/ecs/spec.go
+++ b/platform/ecs/spec.go
@@ -2,7 +2,7 @@ package ecs
 
 import (
 	"context"
-	"strings"
+	"path"
 
 	"github.com/aws/aws-sdk-go/aws/arn"
 
@@ -12,8 +12,6 @@ import (
 	"github.com/mackerelio/mackerel-container-agent/platform/ecs/task"
 	agentSpec "github.com/mackerelio/mackerel-container-agent/spec"
 )
-
-const resourcePrefix = "task/"
 
 type ecsSpec struct {
 	Cluster       string         `json:"cluster,omitempty"`
@@ -71,7 +69,7 @@ func (g *specGenerator) Generate(ctx context.Context) (interface{}, error) {
 
 	spec := &ecsSpec{
 		Cluster:       meta.Instance.Cluster,
-		Task:          strings.TrimPrefix(taskARN.Resource, resourcePrefix),
+		Task:          path.Base(taskARN.Resource), // Resource format: 'task/task-id' or 'task/cluster-name/task-id'
 		TaskARN:       meta.Arn,
 		TaskFamily:    meta.Family,
 		TaskVersion:   meta.Version,

--- a/platform/ecs/spec_test.go
+++ b/platform/ecs/spec_test.go
@@ -16,11 +16,20 @@ import (
 )
 
 func TestGenerateSpec(t *testing.T) {
+	var isNewARN bool
+
 	mockTask := task.NewMockTask(
 		task.MockMetadata(
 			func(context.Context) (*task.Metadata, error) {
+				var resource string
+				if isNewARN {
+					resource = "task/cluster-name/task-id"
+				} else {
+					resource = "task/e01d58a8-151b-40e8-bc01-22647b9ecfec"
+				}
+
 				return &task.Metadata{
-					Arn: "arn:aws:ecs:us-east-1:999999999999:task/e01d58a8-151b-40e8-bc01-22647b9ecfec",
+					Arn: "arn:aws:ecs:us-east-1:999999999999:" + resource,
 					Containers: []task.Container{
 						{
 							DockerID:   "79c796ed2a7f864f485c76f83f3165488097279d296a7c05bd5201a1c69b2920",
@@ -53,52 +62,66 @@ func TestGenerateSpec(t *testing.T) {
 
 	generator := newSpecGenerator(mockTask)
 
-	got, err := generator.Generate(context.Background())
-	if err != nil {
-		t.Errorf("Generate() should not raise error: %v", err)
+	tests := []struct {
+		isNewARN bool
+		taskARN  string
+		task     string
+	}{
+		{false, "arn:aws:ecs:us-east-1:999999999999:task/e01d58a8-151b-40e8-bc01-22647b9ecfec", "e01d58a8-151b-40e8-bc01-22647b9ecfec"},
+		{true, "arn:aws:ecs:us-east-1:999999999999:task/cluster-name/task-id", "task-id"},
 	}
 
-	v, ok := got.(*agentSpec.CloudHostname)
-	if !ok {
-		t.Errorf("Generate() should return *spec.CloudHostname got %T", got)
-	}
-	if v.Cloud.Provider != "ecs" {
-		t.Errorf("Provider should %q, got %q", "ecs", v.Cloud.Provider)
-	}
+	for _, tc := range tests {
+		isNewARN = tc.isNewARN
 
-	expected := &agentSpec.CloudHostname{
-		Cloud: &mackerel.Cloud{
-			Provider: string(platform.ECS),
-			MetaData: &ecsSpec{
-				Cluster:       "mackerel-container-agent",
-				Task:          "e01d58a8-151b-40e8-bc01-22647b9ecfec",
-				TaskARN:       "arn:aws:ecs:us-east-1:999999999999:task/e01d58a8-151b-40e8-bc01-22647b9ecfec",
-				TaskFamily:    "nginx-develop",
-				TaskVersion:   "2",
-				DesiredStatus: "RUNNING",
-				KnownStatus:   "RUNNING",
-				Containers: []container{
-					container{
-						DockerID:   "79c796ed2a7f864f485c76f83f3165488097279d296a7c05bd5201a1c69b2920",
-						DockerName: "ecs-nginx-efs-2-nginx-9ac0808dd0afa495f001",
-						Name:       "nginx",
+		got, err := generator.Generate(context.Background())
+		if err != nil {
+			t.Errorf("Generate() should not raise error: %v", err)
+		}
+
+		v, ok := got.(*agentSpec.CloudHostname)
+		if !ok {
+			t.Errorf("Generate() should return *spec.CloudHostname got %T", got)
+		}
+		if v.Cloud.Provider != "ecs" {
+			t.Errorf("Provider should %q, got %q", "ecs", v.Cloud.Provider)
+		}
+
+		expected := &agentSpec.CloudHostname{
+			Cloud: &mackerel.Cloud{
+				Provider: string(platform.ECS),
+				MetaData: &ecsSpec{
+					Cluster:       "mackerel-container-agent",
+					Task:          tc.task,
+					TaskARN:       tc.taskARN,
+					TaskFamily:    "nginx-develop",
+					TaskVersion:   "2",
+					DesiredStatus: "RUNNING",
+					KnownStatus:   "RUNNING",
+					Containers: []container{
+						container{
+							DockerID:   "79c796ed2a7f864f485c76f83f3165488097279d296a7c05bd5201a1c69b2920",
+							DockerName: "ecs-nginx-efs-2-nginx-9ac0808dd0afa495f001",
+							Name:       "nginx",
+						},
+						container{
+							DockerID:   "7e088b28bde202f19243853b0d20998a005984efa3d4b6c18e771fd149f86648",
+							DockerName: "ecs-mackerel-container-agent-7-mackerel-container-agent-96b2f7c0c7c2ccff9101",
+							Name:       "mackerel-container-agent",
+						},
 					},
-					container{
-						DockerID:   "7e088b28bde202f19243853b0d20998a005984efa3d4b6c18e771fd149f86648",
-						DockerName: "ecs-mackerel-container-agent-7-mackerel-container-agent-96b2f7c0c7c2ccff9101",
-						Name:       "mackerel-container-agent",
+					Limits: resourceLimits{
+						CPU:    float64(runtime.NumCPU()),
+						Memory: uint64(134217728),
 					},
-				},
-				Limits: resourceLimits{
-					CPU:    float64(runtime.NumCPU()),
-					Memory: uint64(134217728),
 				},
 			},
-		},
-		Hostname: "e01d58a8-151b-40e8-bc01-22647b9ecfec",
+			Hostname: tc.task,
+		}
+
+		if !reflect.DeepEqual(v, expected) {
+			t.Errorf("Generate() expected %v, got %v", expected, v)
+		}
 	}
 
-	if !reflect.DeepEqual(v, expected) {
-		t.Errorf("Generate() expected %v, got %v", expected, v)
-	}
 }

--- a/platform/ecsawsvpc/spec.go
+++ b/platform/ecsawsvpc/spec.go
@@ -2,7 +2,7 @@ package ecsawsvpc
 
 import (
 	"context"
-	"strings"
+	"path"
 	"time"
 
 	ecsTypes "github.com/aws/amazon-ecs-agent/agent/handlers/v2"
@@ -14,8 +14,6 @@ import (
 	"github.com/mackerelio/mackerel-container-agent/platform/ecsawsvpc/taskmetadata"
 	agentSpec "github.com/mackerelio/mackerel-container-agent/spec"
 )
-
-const resourcePrefix = "task/"
 
 type specGenerator struct {
 	client    taskmetadata.Client
@@ -123,7 +121,7 @@ func generateSpec(task *ecsTypes.TaskResponse) (*taskSpec, error) {
 
 	spec := &taskSpec{
 		Cluster:            task.Cluster,
-		Task:               strings.TrimPrefix(taskARN.Resource, resourcePrefix),
+		Task:               path.Base(taskARN.Resource), // Resource format: 'task/task-id' or 'task/cluster-name/task-id'
 		TaskARN:            task.TaskARN,
 		TaskFamily:         task.Family,
 		TaskVersion:        task.Revision,


### PR DESCRIPTION
Improve getting TaskID.

Format of Resouce in new ARN is "task/cluster-name/task-id".
see. https://docs.aws.amazon.com/AmazonECS/latest/userguide/ecs-resource-ids.html