### PR TITLE
retry request to the "/task" API

### DIFF
--- a/platform/ecsv3/ecs.go
+++ b/platform/ecsv3/ecs.go
@@ -149,7 +149,8 @@ func detectNetworkMode(meta *ecsTypes.TaskResponse) (networkMode, error) {
 }
 
 func getTaskMetadata(ctx context.Context, client TaskMetadataGetter, interval time.Duration) (*ecsTypes.TaskResponse, error) {
-	// Retry until GetTaskMetadata succeeds.
+	// GetTaskMetadata will return an error until all containers associated with the task have been created.
+	// To avoid exiting with this error, retry until GetTaskMetadata succeeds.
 	for {
 		meta, err := client.GetTaskMetadata(ctx)
 		if err == nil {

--- a/platform/ecsv3/internal/mock_taskmetadatagetter.go
+++ b/platform/ecsv3/internal/mock_taskmetadatagetter.go
@@ -1,0 +1,45 @@
+package internal
+
+import (
+	"context"
+	"errors"
+
+	ecsTypes "github.com/aws/amazon-ecs-agent/agent/handlers/v2"
+)
+
+// MockTaskMetadataGetter is a mock of /task API endpoint
+type MockTaskMetadataGetter struct {
+	getTaskMetadataCallback func(context.Context) (*ecsTypes.TaskResponse, error)
+}
+
+// MockTaskMetadataGetterOption represents an option of mock client of /task API endpoint
+type MockTaskMetadataGetterOption func(*MockTaskMetadataGetter)
+
+// NewMockTaskMetadataGetter creates a new mock of /task API endpoint
+func NewMockTaskMetadataGetter(opts ...MockTaskMetadataGetterOption) *MockTaskMetadataGetter {
+	g := &MockTaskMetadataGetter{}
+	for _, o := range opts {
+		g.ApplyOption(o)
+	}
+	return g
+}
+
+// ApplyOption applies a mock option
+func (g *MockTaskMetadataGetter) ApplyOption(opt MockTaskMetadataGetterOption) {
+	opt(g)
+}
+
+// GetTaskMetadata returns /task API response
+func (g *MockTaskMetadataGetter) GetTaskMetadata(ctx context.Context) (*ecsTypes.TaskResponse, error) {
+	if g.getTaskMetadataCallback != nil {
+		return g.getTaskMetadataCallback(ctx)
+	}
+	return nil, errors.New("MockGetTaskMetadata not found")
+}
+
+// MockGetTaskMetadata returns an option to set the callback of GetTaskMetadata
+func MockGetTaskMetadata(callback func(context.Context) (*ecsTypes.TaskResponse, error)) MockTaskMetadataGetterOption {
+	return func(g *MockTaskMetadataGetter) {
+		g.getTaskMetadataCallback = callback
+	}
+}


### PR DESCRIPTION
-In the ecs_v3 platform, access / task API in constructor to resolve network mode.
-The / task API returns an error if all containers associated with the task have not been created.
-Retry the request until the / task API no longer returns an error.