### PR TITLE
Release version 0.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.0.4 (2019-05-16)
+
+* add build-and-push-dockerimage script for pushing Docker Image manually #26 (hayajo)
+* notify interrupt signals before creating platform #25 (itchyny)
+* retry request to the "/task" API #24 (hayajo)
+* Improve error message #22 (hayajo)
+* Use k8s packages #19 (hayajo)
+* Add banner image #20 (hayajo)
+* Support Task Metadata Endpoint v3 #17 (hayajo)
+* Support Go Modules #18 (hayajo)
+
+
 ## 0.0.3 (2019-04-04)
 
 * Improve getting TaskID #15 (hayajo)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 BIN := mackerel-container-agent
-VERSION := 0.0.3
+VERSION := 0.0.4
 REVISION := $(shell git rev-parse --short HEAD)
 
 export GO111MODULE=on


### PR DESCRIPTION
- add build-and-push-dockerimage script for pushing Docker Image manually #26
- notify interrupt signals before creating platform #25
- retry request to the "/task" API #24
- Improve error message #22
- Use k8s packages #19
- Add banner image #20
- Support Task Metadata Endpoint v3 #17
- Support Go Modules #18