### PR TITLE
don't use HTTP_PROXY when requesting API

### DIFF
--- a/platform/ecs/agent/client.go
+++ b/platform/ecs/agent/client.go
@@ -39,12 +39,22 @@ func NewClient(baseURL string) (Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &client{
+	dt := http.DefaultTransport.(*http.Transport)
+	c := &client{
 		url: u,
 		httpClient: &http.Client{
 			Timeout: timeout,
+			Transport: &http.Transport{
+				Proxy:                 nil,
+				DialContext:           dt.DialContext,
+				MaxIdleConns:          dt.MaxIdleConns,
+				IdleConnTimeout:       dt.IdleConnTimeout,
+				TLSHandshakeTimeout:   dt.TLSHandshakeTimeout,
+				ExpectContinueTimeout: dt.ExpectContinueTimeout,
+			},
 		},
-	}, nil
+	}
+	return c, nil
 }
 
 // GetInstanceMetadata gets instance metadata

--- a/platform/ecs/agent/client_test.go
+++ b/platform/ecs/agent/client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 )
 
@@ -52,5 +53,29 @@ func TestGetTaskMetadata(t *testing.T) {
 	_, err = c.GetTaskMetadataWithDockerID(ctx, dockerID)
 	if err != nil {
 		t.Errorf("GetTaskMetadata() should not raise error: %v", err)
+	}
+}
+
+func TestNoProxy(t *testing.T) {
+	var useProxy bool
+
+	dt := http.DefaultTransport.(*http.Transport)
+	origProxy := dt.Proxy
+	defer func() {
+		dt.Proxy = origProxy
+	}()
+	dt.Proxy = func(req *http.Request) (*url.URL, error) {
+		useProxy = true
+		return nil, nil
+	}
+
+	th := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	ts := httptest.NewServer(th)
+
+	c, _ := NewClient(ts.URL)
+	c.GetTaskMetadataWithDockerID(context.Background(), "")
+
+	if useProxy == true {
+		t.Error("proxy should not be used")
 	}
 }

--- a/platform/ecs/instance/client.go
+++ b/platform/ecs/instance/client.go
@@ -37,12 +37,22 @@ func NewClient(baseURL string) (Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &client{
+	dt := http.DefaultTransport.(*http.Transport)
+	c := &client{
 		url: u,
 		httpClient: &http.Client{
 			Timeout: timeout,
+			Transport: &http.Transport{
+				Proxy:                 nil,
+				DialContext:           dt.DialContext,
+				MaxIdleConns:          dt.MaxIdleConns,
+				IdleConnTimeout:       dt.IdleConnTimeout,
+				TLSHandshakeTimeout:   dt.TLSHandshakeTimeout,
+				ExpectContinueTimeout: dt.ExpectContinueTimeout,
+			},
 		},
-	}, nil
+	}
+	return c, nil
 }
 
 // GetLocalIPv4 gets instance IPv4 address

--- a/platform/ecsawsvpc/taskmetadata/client.go
+++ b/platform/ecsawsvpc/taskmetadata/client.go
@@ -42,13 +42,23 @@ func NewClient(baseURL string, ignoreContainer *regexp.Regexp) (Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &client{
+	dt := http.DefaultTransport.(*http.Transport)
+	c := &client{
 		url: u,
 		httpClient: &http.Client{
 			Timeout: timeout,
+			Transport: &http.Transport{
+				Proxy:                 nil,
+				DialContext:           dt.DialContext,
+				MaxIdleConns:          dt.MaxIdleConns,
+				IdleConnTimeout:       dt.IdleConnTimeout,
+				TLSHandshakeTimeout:   dt.TLSHandshakeTimeout,
+				ExpectContinueTimeout: dt.ExpectContinueTimeout,
+			},
 		},
 		ignoreContainer: ignoreContainer,
-	}, nil
+	}
+	return c, nil
 }
 
 // GetMetadata gets task metadata

--- a/platform/ecsawsvpc/taskmetadata/client_test.go
+++ b/platform/ecsawsvpc/taskmetadata/client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"regexp"
 	"testing"
 )
@@ -91,4 +92,28 @@ func TestIgnoreContainer(t *testing.T) {
 		}
 	}
 
+}
+
+func TestNoProxy(t *testing.T) {
+	var useProxy bool
+
+	dt := http.DefaultTransport.(*http.Transport)
+	origProxy := dt.Proxy
+	defer func() {
+		dt.Proxy = origProxy
+	}()
+	dt.Proxy = func(req *http.Request) (*url.URL, error) {
+		useProxy = true
+		return nil, nil
+	}
+
+	th := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	ts := httptest.NewServer(th)
+
+	c, _ := NewClient(ts.URL, nil)
+	c.GetMetadata(context.Background())
+
+	if useProxy == true {
+		t.Error("proxy should not be used")
+	}
 }

--- a/platform/ecsv3/taskmetadata/client.go
+++ b/platform/ecsv3/taskmetadata/client.go
@@ -35,13 +35,23 @@ func NewClient(metadataURI string, ignoreContainer *regexp.Regexp) (*Client, err
 	if err != nil {
 		return nil, err
 	}
-	return &Client{
+	dt := http.DefaultTransport.(*http.Transport)
+	c := &Client{
 		url: u,
 		httpClient: &http.Client{
 			Timeout: timeout,
+			Transport: &http.Transport{
+				Proxy:                 nil,
+				DialContext:           dt.DialContext,
+				MaxIdleConns:          dt.MaxIdleConns,
+				IdleConnTimeout:       dt.IdleConnTimeout,
+				TLSHandshakeTimeout:   dt.TLSHandshakeTimeout,
+				ExpectContinueTimeout: dt.ExpectContinueTimeout,
+			},
 		},
 		ignoreContainer: ignoreContainer,
-	}, nil
+	}
+	return c, nil
 }
 
 // GetTaskMetadata gets task metadata

--- a/platform/ecsv3/taskmetadata/client_test.go
+++ b/platform/ecsv3/taskmetadata/client_test.go
@@ -166,3 +166,27 @@ func TestErrorMessage(t *testing.T) {
 		}
 	}
 }
+
+func TestNoProxy(t *testing.T) {
+	var useProxy bool
+
+	dt := http.DefaultTransport.(*http.Transport)
+	origProxy := dt.Proxy
+	defer func() {
+		dt.Proxy = origProxy
+	}()
+	dt.Proxy = func(req *http.Request) (*url.URL, error) {
+		useProxy = true
+		return nil, nil
+	}
+
+	th := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	ts := httptest.NewServer(th)
+
+	c, _ := NewClient(ts.URL, nil)
+	c.GetTaskMetadata(context.Background())
+
+	if useProxy == true {
+		t.Error("proxy should not be used")
+	}
+}

--- a/platform/kubernetes/kubernetes.go
+++ b/platform/kubernetes/kubernetes.go
@@ -115,8 +115,8 @@ func createHTTPClient(caCert []byte, insecureTLS bool) *http.Client {
 		DualStack: true,
 	}
 	// Copy from the definition of http.DefaultTransport.
+	// Don't use Proxy.
 	transport := &http.Transport{
-		Proxy:                 http.ProxyFromEnvironment,
 		Dial:                  dialer.Dial,
 		DialContext:           dialer.DialContext,
 		MaxIdleConns:          100,

--- a/platform/kubernetes/kubernetes_test.go
+++ b/platform/kubernetes/kubernetes_test.go
@@ -77,5 +77,8 @@ func TestCreateHTTPClient(t *testing.T) {
 		if resp != nil {
 			resp.Body.Close()
 		}
+		if client.Transport.(*http.Transport).Proxy != nil {
+			t.Error("proxy should not be used")
+		}
 	}
 }


### PR DESCRIPTION
- Local HTTP proxy environment affect the API request.
- Fixed to not use HTTP proxy in API request.