### PR TITLE
don't use HTTP_PROXY when requesting HTTP probe

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -343,6 +343,8 @@ plugin:
 }
 
 func TestReadinessProbe(t *testing.T) {
+	proxy, _ := url.Parse("http://proxy.example.com:8080")
+
 	testCases := []struct {
 		name      string
 		config    string
@@ -443,6 +445,7 @@ readinessProbe:
         value: test
       - name: Host
         value: example.com
+    proxy: "http://proxy.example.com:8080"
   initialDelaySeconds: 10
   timeoutSeconds: 5
   periodSeconds: 3
@@ -457,6 +460,7 @@ readinessProbe:
 						Port:    "8080",
 						Path:    "/healthy",
 						Headers: []Header{{"X-Custom-Header", "test"}, {"Host", "example.com"}},
+						Proxy:   URLWrapper{proxy},
 					},
 					InitialDelaySeconds: 10,
 					TimeoutSeconds:      5,

--- a/config/probe.go
+++ b/config/probe.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"errors"
+	"net/url"
 
 	"github.com/mackerelio/mackerel-container-agent/cmdutil"
 )
@@ -60,12 +61,25 @@ type ProbeHTTP struct {
 	Path      string   `yaml:"path"`
 	Headers   []Header `yaml:"headers"`
 	UserAgent string
+	Proxy     URLWrapper `yaml:"proxy"`
 }
 
 // Header is a request header for http probe.
 type Header struct {
 	Name  string `yaml:"name"`
 	Value string `yaml:"value"`
+}
+
+// URLWrapper wraps url.URL
+type URLWrapper struct {
+	*url.URL
+}
+
+// UnmarshalText decodes host status string
+func (u *URLWrapper) UnmarshalText(text []byte) error {
+	var err error
+	u.URL, err = url.Parse(string(text))
+	return err
 }
 
 // ProbeTCP is a probe with tcp.

--- a/go.mod
+++ b/go.mod
@@ -53,6 +53,7 @@ require (
 	golang.org/x/sync v0.0.0-20190412183630-56d357773e84
 	golang.org/x/sys v0.0.0-20190416152802-12500544f89f // indirect
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 // indirect
+	google.golang.org/appengine v1.4.0 // indirect
 	google.golang.org/genproto v0.0.0-20190415143225-d1146b9035b9 // indirect
 	google.golang.org/grpc v1.20.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/probe/http_test.go
+++ b/probe/http_test.go
@@ -131,7 +131,7 @@ func TestProbeHTTP_Check(t *testing.T) {
 					Method:  tc.method,
 					Path:    tc.path,
 					Headers: tc.headers,
-					Proxy:   config.URLWrapper{proxyURL},
+					Proxy:   config.URLWrapper{URL: proxyURL},
 				},
 				TimeoutSeconds: tc.timeoutSeconds,
 			})

--- a/probe/http_test.go
+++ b/probe/http_test.go
@@ -26,6 +26,7 @@ func TestProbeHTTP_Check(t *testing.T) {
 		status         int
 		sleep          time.Duration
 		shouldErr      bool
+		useProxy       bool
 	}{
 		{
 			name:   "ok",
@@ -81,6 +82,23 @@ func TestProbeHTTP_Check(t *testing.T) {
 			headers: []config.Header{{Name: "Host", Value: "example.com"}},
 			status:  http.StatusOK,
 		},
+		{
+			name:     "proxy",
+			path:     "/",
+			status:   http.StatusOK,
+			useProxy: true,
+		},
+	}
+
+	var proxyHandler func(*http.Request) (*url.URL, error)
+
+	dt := http.DefaultTransport.(*http.Transport)
+	origProxy := dt.Proxy
+	defer func() {
+		dt.Proxy = origProxy
+	}()
+	dt.Proxy = func(req *http.Request) (*url.URL, error) {
+		return proxyHandler(req)
 	}
 
 	for _, tc := range testCases {
@@ -88,6 +106,22 @@ func TestProbeHTTP_Check(t *testing.T) {
 			ts := newHTTPServer(t, "ok", tc.headers, tc.method, tc.path, tc.sleep, tc.status)
 			defer ts.Close()
 			u, _ := url.Parse(ts.URL)
+
+			var passedProxy bool
+			proxyHandler = func(req *http.Request) (*url.URL, error) {
+				passedProxy = true
+				return nil, nil
+			}
+
+			var proxyURL *url.URL
+			if tc.useProxy {
+				ps := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					passedProxy = true
+					ts.Config.Handler.ServeHTTP(w, r)
+				}))
+				proxyURL, _ = url.Parse(ps.URL)
+				defer ps.Close()
+			}
 
 			p := NewProbe(&config.Probe{
 				HTTP: &config.ProbeHTTP{
@@ -97,10 +131,19 @@ func TestProbeHTTP_Check(t *testing.T) {
 					Method:  tc.method,
 					Path:    tc.path,
 					Headers: tc.headers,
+					Proxy:   config.URLWrapper{proxyURL},
 				},
 				TimeoutSeconds: tc.timeoutSeconds,
 			})
+
 			err := p.Check(context.Background())
+
+			if tc.useProxy && !passedProxy {
+				t.Errorf("request should through the proxy")
+			}
+			if !tc.useProxy && passedProxy {
+				t.Errorf("request should not through the proxy")
+			}
 
 			if err != nil && !tc.shouldErr {
 				t.Errorf("should not raise error: %v", err)


### PR DESCRIPTION
- Local HTTP proxy environment affect the HTTP probe request.
- Fixed to not use HTTP proxy in HTTP probe request.
- Add the `proxy` item to HTTP probe configuration to use proxy in HTTP probe request.