### PR TITLE
Provide the plugin bundled Docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,6 +86,7 @@ jobs:
           command: |
             TAG=v$(echo ${CIRCLE_BRANCH} | sed -E 's/.*-([0-9.]+)$/\1/')
             docker build -t $DOCKER_REPOSITORY:${TAG:?'parse failed'}${TAG_SUFFIX} .
+            docker build -build-arg REPOSITORY=${DOCKER_REPOSITORY} --build-arg TAG=${TAG}${TAG_SUFFIX} -t ${DOCKER_REPOSITORY}:${TAG}-plugins${TAG_SUFFIX} -f Dockerfile.plugins .
 
       - run:
           name: Push Docker Image
@@ -112,17 +113,17 @@ jobs:
 
       - run:
           name: Build Docker Image
-          command: >
-            docker build
-            -t $DOCKER_REPOSITORY:latest
-            -t $DOCKER_REPOSITORY:${CIRCLE_TAG}
-            .
+          command: |
+            docker build -t $DOCKER_REPOSITORY:latest -t $DOCKER_REPOSITORY:${CIRCLE_TAG} .
+            docker build -build-arg REPOSITORY=${DOCKER_REPOSITORY} --build-arg TAG=${CIRCLE_TAG} -t ${DOCKER_REPOSITORY}:plugins -t ${DOCKER_REPOSITORY}:${CIRCLE_TAG}-plugins -f Dockerfile.plugins .
 
       - run:
           name: Push Docker Image
           command: |
             docker push $DOCKER_REPOSITORY:latest
             docker push $DOCKER_REPOSITORY:${CIRCLE_TAG}
+            docker push $DOCKER_REPOSITORY:plugins
+            docker push $DOCKER_REPOSITORY:${CIRCLE_TAG}-plugins
 
 workflows:
   version: 2

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,9 @@ FROM debian:stretch-slim
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update -yq && \
-    apt-get install -yq --no-install-recommends ca-certificates sudo
+    apt-get install -yq --no-install-recommends ca-certificates sudo && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists
 
 COPY build/mackerel-container-agent /usr/local/bin/
 

--- a/Dockerfile.plugins
+++ b/Dockerfile.plugins
@@ -17,5 +17,5 @@ RUN apt-get update -yq && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists
 
-RUN find /usr/bin/ -type l -regextype posix-egrep -name 'mackerel-plugin-*' -a ! -regex ".*mackerel-plugin-(${BUNDLE_AGENT_PLUGINS})" | xargs /bin/rm
-RUN find /usr/bin/ -type l -regextype posix-egrep -name 'check-*' -a ! -regex ".*check-(${BUNDLE_CHECK_PLUGINS})" | xargs /bin/rm
+RUN find /usr/bin/ -type l -regextype posix-egrep -name 'mackerel-plugin-*' -a ! -regex ".*mackerel-plugin-(${BUNDLE_AGENT_PLUGINS})" -delete
+RUN find /usr/bin/ -type l -regextype posix-egrep -name 'check-*' -a ! -regex ".*check-(${BUNDLE_CHECK_PLUGINS})" -delete

--- a/Dockerfile.plugins
+++ b/Dockerfile.plugins
@@ -4,6 +4,8 @@ ARG TAG
 FROM $REPOSITORY:$TAG
 
 ENV DEBIAN_FRONTEND noninteractive
+ENV BUNDLE_AGENT_PLUGINS apache2|elasticsearch|fluentd|gostats|haproxy|jmx-jolokia|memcached|mysql|nginx|php-apc|php-fpm|php-opcache|plack|postgres|redis|sidekiq|snmp|squid|uwsgi-vassal
+ENV BUNDLE_CHECK_PLUGINS cert-file|elasticsearch|file-age|file-size|http|jmx-jolokia|log|memcached|mysql|postgresql|redis|ssh|ssl-cert|tcp
 
 RUN apt-get update -yq && \
     apt-get install -yq --no-install-recommends curl gnupg2
@@ -14,3 +16,6 @@ RUN apt-get update -yq && \
     apt-get install -yq --no-install-recommends mackerel-agent-plugins mackerel-check-plugins && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists
+
+RUN find /usr/bin/ -type l -regextype posix-egrep -name 'mackerel-plugin-*' -a ! -regex ".*mackerel-plugin-(${BUNDLE_AGENT_PLUGINS})" | xargs /bin/rm
+RUN find /usr/bin/ -type l -regextype posix-egrep -name 'check-*' -a ! -regex ".*check-(${BUNDLE_CHECK_PLUGINS})" | xargs /bin/rm

--- a/Dockerfile.plugins
+++ b/Dockerfile.plugins
@@ -1,0 +1,16 @@
+ARG REPOSITORY
+ARG TAG
+
+FROM $REPOSITORY:$TAG
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update -yq && \
+    apt-get install -yq --no-install-recommends curl gnupg2
+RUN echo "deb [arch=amd64] http://apt.mackerel.io/v2/ mackerel contrib" > /etc/apt/sources.list.d/mackerel.list
+RUN curl -LfsS https://mackerel.io/file/cert/GPG-KEY-mackerel-v2 | apt-key add -
+
+RUN apt-get update -yq && \
+    apt-get install -yq --no-install-recommends mackerel-agent-plugins mackerel-check-plugins && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists


### PR DESCRIPTION
Provide the plugin bundled Docker image in the following `repository:tag`.

- mackerel/mackerel-container-agent:vX.Y.Z-plugins-alpha
- mackerel/mackerel-container-agent:plugins
  - FROM mackerel/mackerel-container-agent:latest
- mackerel/mackerel-container-agent:vX.Y.Z-plugins