### PR TITLE
Release version 0.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.0.5 (2019-05-27)
+
+* Provide the plugin bundled Docker image #30 (hayajo)
+* don't use HTTP_PROXY when requesting HTTP probe #29 (hayajo)
+* don't use HTTP_PROXY when requesting API #28 (hayajo)
+
+
 ## 0.0.4 (2019-05-16)
 
 * add build-and-push-dockerimage script for pushing Docker Image manually #26 (hayajo)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 BIN := mackerel-container-agent
-VERSION := 0.0.4
+VERSION := 0.0.5
 REVISION := $(shell git rev-parse --short HEAD)
 
 export GO111MODULE=on


### PR DESCRIPTION
- Provide the plugin bundled Docker image #30
- don't use HTTP_PROXY when requesting HTTP probe #29
- don't use HTTP_PROXY when requesting API #28