### PR TITLE
Get s3 region

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -53,7 +53,7 @@ func (a *agent) start(ctx context.Context) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	conf, err := config.Load(os.Getenv("MACKEREL_AGENT_CONFIG"))
+	conf, err := config.Load(ctx, os.Getenv("MACKEREL_AGENT_CONFIG"))
 	if err != nil {
 		return err
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -168,7 +168,7 @@ func fetch(ctx context.Context, location string) ([]byte, error) {
 
 	switch u.Scheme {
 	case "http", "https":
-		return fetchHTTP(u)
+		return fetchHTTP(ctx, u)
 	case "s3":
 		return fetchS3(ctx, u)
 	default:
@@ -180,11 +180,18 @@ func fetchFile(path string) ([]byte, error) {
 	return ioutil.ReadFile(path)
 }
 
-func fetchHTTP(u *url.URL) ([]byte, error) {
+func fetchHTTP(ctx context.Context, u *url.URL) ([]byte, error) {
+	req, err := http.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.WithContext(ctx)
+
 	cl := http.Client{
 		Timeout: timeout,
 	}
-	resp, err := cl.Get(u.String())
+
+	resp, err := cl.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -107,13 +108,13 @@ func parseConfig(data []byte) (*Config, error) {
 }
 
 // Load loads agent configuration
-func Load(location string) (*Config, error) {
+func Load(ctx context.Context, location string) (*Config, error) {
 	var conf *Config
 
 	if location == "" {
 		conf = defaultConfig()
 	} else {
-		data, err := fetch(location)
+		data, err := fetch(ctx, location)
 		if err != nil {
 			return nil, err
 		}
@@ -159,7 +160,7 @@ func Load(location string) (*Config, error) {
 	return conf, nil
 }
 
-func fetch(location string) ([]byte, error) {
+func fetch(ctx context.Context, location string) ([]byte, error) {
 	u, err := url.Parse(location)
 	if err != nil {
 		return fetchFile(location)
@@ -169,7 +170,7 @@ func fetch(location string) ([]byte, error) {
 	case "http", "https":
 		return fetchHTTP(u)
 	case "s3":
-		return fetchS3(u)
+		return fetchS3(ctx, u)
 	default:
 		return fetchFile(u.Path)
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -23,7 +24,7 @@ apikey: 'DUMMY APIKEY'
 
 func TestLoadDefault(t *testing.T) {
 	os.Clearenv()
-	conf, err := Load("")
+	conf, err := Load(context.Background(), "")
 	if err != nil {
 		t.Errorf("should not raise error: %v", err)
 	}
@@ -48,7 +49,7 @@ root: '/tmp/mackerel-container-agent'
 		Root:    "/tmp/mackerel-container-agent",
 	}
 
-	conf, err := Load(file.Name())
+	conf, err := Load(context.Background(), file.Name())
 	if err != nil {
 		t.Errorf("should not raise error: %v", err)
 	}
@@ -67,7 +68,7 @@ func TestLoadHTTP(t *testing.T) {
 		Root:    "/var/tmp/mackerel-container-agent",
 	}
 
-	conf, err := Load(ts.URL)
+	conf, err := Load(context.Background(), ts.URL)
 	if err != nil {
 		t.Errorf("should not raise error: %v", err)
 	}
@@ -89,7 +90,7 @@ func TestLoadS3(t *testing.T) {
 		Root:    "/var/tmp/mackerel-container-agent",
 	}
 
-	conf, err := Load("s3://bucket/key")
+	conf, err := Load(context.Background(), "s3://bucket/key")
 	if err != nil {
 		t.Errorf("should not raise error: %v", err)
 	}
@@ -140,7 +141,7 @@ apikey: 'DUMMY APIKEY'
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			conf, err := Load(tc.location)
+			conf, err := Load(context.Background(), tc.location)
 			if err != nil {
 				t.Errorf("should not raise error: %v", err)
 			}
@@ -190,7 +191,7 @@ roles:
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			conf, err := Load(tc.location)
+			conf, err := Load(context.Background(), tc.location)
 			if err != nil {
 				t.Errorf("should not raise error: %v", err)
 			}
@@ -240,7 +241,7 @@ ignoreContainer: "^mackerel-.+$"
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			conf, err := Load(tc.location)
+			conf, err := Load(context.Background(), tc.location)
 			if err != nil {
 				t.Errorf("should not raise error: %v", err)
 			}
@@ -327,7 +328,7 @@ plugin:
 		},
 	}
 
-	conf, err := Load(file.Name())
+	conf, err := Load(context.Background(), file.Name())
 	if err != nil {
 		t.Errorf("should not raise error: %v", err)
 	}
@@ -573,7 +574,7 @@ readinessProbe:
 			}
 			defer os.Remove(file.Name())
 
-			conf, err := Load(file.Name())
+			conf, err := Load(context.Background(), file.Name())
 			if err != nil && !tc.shouldErr {
 				t.Fatalf("should not raise error: %v", err)
 			}
@@ -680,7 +681,7 @@ hostStatusOnStart: working
 			}
 			defer os.Remove(file.Name())
 
-			conf, err := Load(file.Name())
+			conf, err := Load(context.Background(), file.Name())
 			if err != nil && !tc.shouldErr {
 				t.Fatalf("should not raise error: %v", err)
 			}
@@ -720,7 +721,7 @@ type mockS3Downloader struct {
 	content string
 }
 
-func (m *mockS3Downloader) download(u *url.URL) ([]byte, error) {
+func (m *mockS3Downloader) download(ctx context.Context, u *url.URL) ([]byte, error) {
 	return []byte(m.content), nil
 }
 

--- a/config/s3.go
+++ b/config/s3.go
@@ -42,7 +42,7 @@ func (d s3Downloader) download(ctx context.Context, u *url.URL) ([]byte, error) 
 }
 
 var s3downloader downloader = s3Downloader{
-	regionHint: "ap-notrheast-1",
+	regionHint: "ap-northeast-1",
 }
 
 func fetchS3(ctx context.Context, u *url.URL) ([]byte, error) {


### PR DESCRIPTION
- When accessing `s3: //`,  specifying a region is mandatory.
- Fix to access after resolving the specified bucket region.