### PR TITLE
Delay host retirement for hangup signal and config reload

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -38,6 +38,12 @@ type agent struct {
 func (a *agent) Run(_ []string) error {
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGHUP)
+	retires := make([]func(), 0, 1)
+	defer func() {
+		for _, retire := range retires {
+			retire()
+		}
+	}()
 	confLoader, err := createConfLoader()
 	if err != nil {
 		return err
@@ -50,7 +56,13 @@ func (a *agent) Run(_ []string) error {
 			return err
 		}
 		errCh := make(chan error)
-		go func() { errCh <- a.start(ctx, conf) }()
+		go func() {
+			retire, err := a.start(ctx, conf)
+			if retire != nil {
+				retires = append(retires, retire)
+			}
+			errCh <- err
+		}()
 		confCh := confLoader.Start(ctx)
 		select {
 		case <-sigCh:
@@ -77,7 +89,7 @@ func createConfLoader() (*config.Loader, error) {
 	return config.NewLoader(os.Getenv("MACKEREL_AGENT_CONFIG"), pollingDuration), nil
 }
 
-func (a *agent) start(ctx context.Context, conf *config.Config) error {
+func (a *agent) start(ctx context.Context, conf *config.Config) (func(), error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -85,7 +97,7 @@ func (a *agent) start(ctx context.Context, conf *config.Config) error {
 	if conf.Apibase != "" {
 		baseURL, err := url.Parse(conf.Apibase)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		client.BaseURL = baseURL
 	}
@@ -113,7 +125,7 @@ func (a *agent) start(ctx context.Context, conf *config.Config) error {
 
 	pform, err := NewPlatform(ctx, conf.IgnoreContainer.Regexp)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	customIdentifier, err := pform.GetCustomIdentifier(ctx)

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -65,7 +65,8 @@ func (a *agent) Run(_ []string) error {
 		}()
 		confCh := confLoader.Start(ctx)
 		select {
-		case <-sigCh:
+		case sig := <-sigCh:
+			logger.Infof("reload config: signal = %s", sig)
 			cancel()
 		case <-confCh:
 			cancel()

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -119,7 +119,7 @@ func TestAgentRun_RetryMetricPost(t *testing.T) {
 	checkManager := check.NewManager(createMockCheckGenerators(), client)
 	specManager := spec.NewManager(createMockSpecGenerators(), client)
 
-	err := run(ctx, client, metricManager, checkManager, specManager, &mockPlatform{}, conf)
+	_, err := run(ctx, client, metricManager, checkManager, specManager, &mockPlatform{}, conf)
 	if err != nil {
 		t.Errorf("err should be nil but got: %+v", err)
 	}
@@ -173,7 +173,7 @@ func TestAgentRun_ResolveHostIdLazy(t *testing.T) {
 	checkManager := check.NewManager(createMockCheckGenerators(), client)
 	specManager := spec.NewManager(createMockSpecGenerators(), client)
 
-	err := run(ctx, client, metricManager, checkManager, specManager, &mockPlatform{}, conf)
+	_, err := run(ctx, client, metricManager, checkManager, specManager, &mockPlatform{}, conf)
 	if err != nil {
 		t.Errorf("err should be nil but got: %+v", err)
 	}
@@ -215,7 +215,7 @@ func TestAgentRun_NoRetryBadRequest(t *testing.T) {
 	checkManager := check.NewManager(createMockCheckGenerators(), client)
 	specManager := spec.NewManager(createMockSpecGenerators(), client)
 
-	err := run(ctx, client, metricManager, checkManager, specManager, &mockPlatform{}, conf)
+	_, err := run(ctx, client, metricManager, checkManager, specManager, &mockPlatform{}, conf)
 	if err == nil {
 		t.Errorf("err should not be nil but got: %+v", err)
 	}
@@ -225,8 +225,8 @@ func TestAgentRun_NoRetryBadRequest(t *testing.T) {
 	}
 }
 
-func TestAgentRun_AutoRetirement(t *testing.T) {
-	dir, _ := ioutil.TempDir("", "mackerel-container-agent-run-test-auto-retirement")
+func TestAgentRun_Retire(t *testing.T) {
+	dir, _ := ioutil.TempDir("", "mackerel-container-agent-run-test-retire")
 	defer os.Remove(dir)
 	conf := &config.Config{Root: dir}
 	hostID := "abcde"
@@ -254,17 +254,18 @@ func TestAgentRun_AutoRetirement(t *testing.T) {
 		time.Sleep(200 * time.Millisecond)
 		cancel()
 	}()
-	err := run(ctx, client, metricManager, checkManager, specManager, &mockPlatform{}, conf)
+	retire, err := run(ctx, client, metricManager, checkManager, specManager, &mockPlatform{}, conf)
 	if err != nil {
 		t.Errorf("err should be nil but got: %+v", err)
 	}
+	retire()
 	if !retired {
 		t.Errorf("host should be retired")
 	}
 }
 
-func TestAgentRun_AutoRetirement_Retry(t *testing.T) {
-	dir, _ := ioutil.TempDir("", "mackerel-container-agent-run-test-auto-retirement-retry")
+func TestAgentRun_Retire_Retry(t *testing.T) {
+	dir, _ := ioutil.TempDir("", "mackerel-container-agent-run-test-retire-retry")
 	defer os.Remove(dir)
 	conf := &config.Config{Root: dir}
 	hostID := "abcde"
@@ -300,17 +301,18 @@ func TestAgentRun_AutoRetirement_Retry(t *testing.T) {
 		time.Sleep(200 * time.Millisecond)
 		cancel()
 	}()
-	err := run(ctx, client, metricManager, checkManager, specManager, &mockPlatform{}, conf)
+	retire, err := run(ctx, client, metricManager, checkManager, specManager, &mockPlatform{}, conf)
 	if err != nil {
 		t.Errorf("err should be nil but got: %+v", err)
 	}
+	retire()
 	if !retired {
 		t.Errorf("host should be retired")
 	}
 }
 
-func TestAgentRun_AutoRetirement_HostIDError(t *testing.T) {
-	dir, _ := ioutil.TempDir("", "mackerel-container-agent-run-test-auto-retirement-error")
+func TestAgentRun_Retire_HostIDError(t *testing.T) {
+	dir, _ := ioutil.TempDir("", "mackerel-container-agent-run-test-retire-hostid-error")
 	defer os.Remove(dir)
 	conf := &config.Config{Root: dir}
 
@@ -337,10 +339,11 @@ func TestAgentRun_AutoRetirement_HostIDError(t *testing.T) {
 		time.Sleep(200 * time.Millisecond)
 		cancel()
 	}()
-	err := run(ctx, client, metricManager, checkManager, specManager, &mockPlatform{}, conf)
+	retire, err := run(ctx, client, metricManager, checkManager, specManager, &mockPlatform{}, conf)
 	if err != nil {
 		t.Errorf("err should be nil but got: %+v", err)
 	}
+	retire() // fails because host id is not resolved
 	if retired {
 		t.Errorf("host should not be retired")
 	}
@@ -383,7 +386,7 @@ func TestAgentRun_MetricPlugin(t *testing.T) {
 	checkManager := check.NewManager(nil, client)
 	specManager := spec.NewManager(createMockSpecGenerators(), client)
 
-	err := run(ctx, client, metricManager, checkManager, specManager, &mockPlatform{}, conf)
+	_, err := run(ctx, client, metricManager, checkManager, specManager, &mockPlatform{}, conf)
 	if err != nil {
 		t.Errorf("err should be nil but got: %+v", err)
 	}
@@ -434,7 +437,7 @@ func TestAgentRun_CustomIdentifier(t *testing.T) {
 	checkManager := check.NewManager(createMockCheckGenerators(), client)
 	specManager := spec.NewManager(createMockSpecGenerators(), client).WithCustomIdentifier(customIdentifier)
 
-	err := run(ctx, client, metricManager, checkManager, specManager, &mockPlatform{}, conf)
+	_, err := run(ctx, client, metricManager, checkManager, specManager, &mockPlatform{}, conf)
 	if err != nil {
 		t.Errorf("err should be nil but got: %+v", err)
 	}
@@ -478,7 +481,7 @@ func TestAgentRun_CustomIdentifier_CreateHost(t *testing.T) {
 	checkManager := check.NewManager(createMockCheckGenerators(), client)
 	specManager := spec.NewManager(createMockSpecGenerators(), client).WithCustomIdentifier(customIdentifier)
 
-	err := run(ctx, client, metricManager, checkManager, specManager, &mockPlatform{}, conf)
+	_, err := run(ctx, client, metricManager, checkManager, specManager, &mockPlatform{}, conf)
 	if err != nil {
 		t.Errorf("err should be nil but got: %+v", err)
 	}
@@ -545,7 +548,7 @@ func TestAgentRun_StatusRunning(t *testing.T) {
 	checkManager := check.NewManager(createMockCheckGenerators(), client)
 	specManager := spec.NewManager([]spec.Generator{&mockSpecGeneratorStatus{pform}}, client)
 
-	err := run(ctx, client, metricManager, checkManager, specManager, pform, conf)
+	_, err := run(ctx, client, metricManager, checkManager, specManager, pform, conf)
 	if err != nil {
 		t.Errorf("err should be nil but got: %+v", err)
 	}
@@ -581,7 +584,7 @@ func TestAgentRun_ReadinessProbe(t *testing.T) {
 	metricManager := metric.NewManager(createMockMetricGenerators(), client)
 	checkManager := check.NewManager(createMockCheckGenerators(), client)
 	specManager := spec.NewManager(createMockSpecGenerators(), client)
-	err := run(ctx, client, metricManager, checkManager, specManager, &mockPlatform{}, conf)
+	_, err := run(ctx, client, metricManager, checkManager, specManager, &mockPlatform{}, conf)
 	if err != nil {
 		t.Errorf("err should be nil but got: %+v", err)
 	}
@@ -612,7 +615,7 @@ func TestAgentRun_ReadinessProbe_SleepLong(t *testing.T) {
 	metricManager := metric.NewManager(createMockMetricGenerators(), client)
 	checkManager := check.NewManager(createMockCheckGenerators(), client)
 	specManager := spec.NewManager(createMockSpecGenerators(), client)
-	err := run(ctx, client, metricManager, checkManager, specManager, &mockPlatform{}, conf)
+	_, err := run(ctx, client, metricManager, checkManager, specManager, &mockPlatform{}, conf)
 	if err != nil {
 		t.Errorf("err should be nil but got: %+v", err)
 	}
@@ -645,7 +648,7 @@ func TestAgentRun_HostStatusOnStart(t *testing.T) {
 	metricManager := metric.NewManager(createMockMetricGenerators(), client)
 	checkManager := check.NewManager(createMockCheckGenerators(), client)
 	specManager := spec.NewManager(createMockSpecGenerators(), client)
-	err := run(ctx, client, metricManager, checkManager, specManager, &mockPlatform{}, conf)
+	_, err := run(ctx, client, metricManager, checkManager, specManager, &mockPlatform{}, conf)
 	if err != nil {
 		t.Errorf("err should be nil but got: %+v", err)
 	}

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -165,7 +165,7 @@ func TestAgentRun_ResolveHostIdLazy(t *testing.T) {
 		}),
 	)
 	go func() {
-		time.Sleep(700 * time.Millisecond)
+		time.Sleep(500 * time.Millisecond)
 		client.ApplyOption(
 			api.MockCreateHost(func(param *mackerel.CreateHostParam) (string, error) {
 				createParam = param

--- a/agent/host_resolver.go
+++ b/agent/host_resolver.go
@@ -48,6 +48,10 @@ func (r *hostResolver) getHost(hostParam *mackerel.CreateHostParam) (*mackerel.H
 				}
 				if len(hosts) > 0 {
 					host = hosts[0]
+					_, err = r.client.UpdateHost(host.ID, (*mackerel.UpdateHostParam)(hostParam))
+					if err != nil {
+						return nil, retryFromError(err), errors.Wrap(err, "failed to update host for id = "+host.ID)
+					}
 					return host, false, r.saveHostID(host.ID)
 				}
 			}
@@ -74,6 +78,10 @@ func (r *hostResolver) getHost(hostParam *mackerel.CreateHostParam) (*mackerel.H
 	host, err = r.client.FindHost(hostID)
 	if err != nil {
 		return nil, retryFromError(err), errors.Wrap(err, "failed to find host for id = "+hostID)
+	}
+	_, err = r.client.UpdateHost(host.ID, (*mackerel.UpdateHostParam)(hostParam))
+	if err != nil {
+		return nil, retryFromError(err), errors.Wrap(err, "failed to update host for id = "+hostID)
 	}
 	return host, false, nil
 }

--- a/agent/retire.go
+++ b/agent/retire.go
@@ -17,6 +17,7 @@ func retire(client api.Client, hostResolver *hostResolver) error {
 		}
 		return err
 	}
+	logger.Infof("retire: host id = %s", hostID)
 	err = retry.Retry(3, 3*time.Second, func() error {
 		return client.RetireHost(hostID)
 	})

--- a/agent/run.go
+++ b/agent/run.go
@@ -33,7 +33,7 @@ func run(
 	specManager *spec.Manager,
 	pform platform.Platform,
 	conf *config.Config,
-) error {
+) (func(), error) {
 	specManager.SetChecks(checkManager.Configs())
 	eg, ctx := errgroup.WithContext(ctx)
 
@@ -121,10 +121,9 @@ func run(
 		return specManager.Run(ctx, specInitialInterval, specInterval)
 	})
 
-	err := eg.Wait()
-	if err := retire(client, hostResolver); err != nil {
-		logger.Warningf("failed to retire: %s", err)
-	}
-
-	return err
+	return func() {
+		if err := retire(client, hostResolver); err != nil {
+			logger.Warningf("failed to retire: %s", err)
+		}
+	}, eg.Wait()
 }


### PR DESCRIPTION
On SIGHUP signal and config changes, the agent should not retire the host, but keep posting the metrics to the previous host. But the host id, and even api key, can change due to the config change, so we have to collect the retirement callbacks at one place (not the host ids) and then fire them when the process exits. Ideally the callback can be fired when the host id is changed, but the implementation will be hard.