### PR TITLE
[nit] Use os.RemoveAll instead of os.Remove in the tests

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -86,7 +86,7 @@ func init() {
 
 func TestAgentRun_RetryMetricPost(t *testing.T) {
 	dir, _ := ioutil.TempDir("", "mackerel-container-agent-run-test-retry")
-	defer os.Remove(dir)
+	defer os.RemoveAll(dir)
 	conf := &config.Config{Root: dir}
 	hostID := "abcde"
 	var postedMetricValues []*mackerel.MetricValue
@@ -131,7 +131,7 @@ func TestAgentRun_RetryMetricPost(t *testing.T) {
 
 func TestAgentRun_ResolveHostIdLazy(t *testing.T) {
 	dir, _ := ioutil.TempDir("", "mackerel-container-agent-run-test-lazy")
-	defer os.Remove(dir)
+	defer os.RemoveAll(dir)
 	conf := &config.Config{Root: dir}
 	hostID := "abcde"
 	var updatedCount int
@@ -204,7 +204,7 @@ func TestAgentRun_ResolveHostIdLazy(t *testing.T) {
 
 func TestAgentRun_NoRetryBadRequest(t *testing.T) {
 	dir, _ := ioutil.TempDir("", "mackerel-container-agent-run-test-bad-request")
-	defer os.Remove(dir)
+	defer os.RemoveAll(dir)
 	conf := &config.Config{Root: dir}
 	hostID := "abcde"
 
@@ -231,7 +231,7 @@ func TestAgentRun_NoRetryBadRequest(t *testing.T) {
 
 func TestAgentRun_Retire(t *testing.T) {
 	dir, _ := ioutil.TempDir("", "mackerel-container-agent-run-test-retire")
-	defer os.Remove(dir)
+	defer os.RemoveAll(dir)
 	conf := &config.Config{Root: dir}
 	hostID := "abcde"
 
@@ -270,7 +270,7 @@ func TestAgentRun_Retire(t *testing.T) {
 
 func TestAgentRun_Retire_Retry(t *testing.T) {
 	dir, _ := ioutil.TempDir("", "mackerel-container-agent-run-test-retire-retry")
-	defer os.Remove(dir)
+	defer os.RemoveAll(dir)
 	conf := &config.Config{Root: dir}
 	hostID := "abcde"
 
@@ -317,7 +317,7 @@ func TestAgentRun_Retire_Retry(t *testing.T) {
 
 func TestAgentRun_Retire_HostIDError(t *testing.T) {
 	dir, _ := ioutil.TempDir("", "mackerel-container-agent-run-test-retire-hostid-error")
-	defer os.Remove(dir)
+	defer os.RemoveAll(dir)
 	conf := &config.Config{Root: dir}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -355,7 +355,7 @@ func TestAgentRun_Retire_HostIDError(t *testing.T) {
 
 func TestAgentRun_MetricPlugin(t *testing.T) {
 	dir, _ := ioutil.TempDir("", "mackerel-container-agent-run-test-metric-plugin")
-	defer os.Remove(dir)
+	defer os.RemoveAll(dir)
 	conf := &config.Config{
 		Root: dir,
 		MetricPlugins: []*config.MetricPlugin{
@@ -411,7 +411,7 @@ func TestAgentRun_MetricPlugin(t *testing.T) {
 
 func TestAgentRun_CustomIdentifier(t *testing.T) {
 	dir, _ := ioutil.TempDir("", "mackerel-container-agent-run-test-custom-identifier")
-	defer os.Remove(dir)
+	defer os.RemoveAll(dir)
 	conf := &config.Config{Root: dir}
 	hostID := "abcde"
 	customIdentifier := "custom-identifier-abcde"
@@ -463,7 +463,7 @@ func TestAgentRun_CustomIdentifier(t *testing.T) {
 
 func TestAgentRun_CustomIdentifier_CreateHost(t *testing.T) {
 	dir, _ := ioutil.TempDir("", "mackerel-container-agent-run-test-custom-identifier-create-host")
-	defer os.Remove(dir)
+	defer os.RemoveAll(dir)
 	conf := &config.Config{Root: dir}
 	hostID := "abcde"
 	customIdentifier := "custom-identifier-abcde"
@@ -518,7 +518,7 @@ func TestAgentRun_CustomIdentifier_CreateHost(t *testing.T) {
 
 func TestAgentRun_HostIDFile(t *testing.T) {
 	dir, _ := ioutil.TempDir("", "mackerel-container-agent-run-test-lazy")
-	defer os.Remove(dir)
+	defer os.RemoveAll(dir)
 	conf := &config.Config{Root: dir}
 	hostID := "abcde"
 	var updatedCount int
@@ -597,7 +597,7 @@ func (g *mockSpecGeneratorStatus) Generate(context.Context) (interface{}, error)
 
 func TestAgentRun_StatusRunning(t *testing.T) {
 	dir, _ := ioutil.TempDir("", "mackerel-container-agent-run-test-status-running")
-	defer os.Remove(dir)
+	defer os.RemoveAll(dir)
 	conf := &config.Config{Root: dir}
 	hostID := "abcde"
 	pform := &mockPlatformStatusRunning{count: 2}
@@ -628,7 +628,7 @@ func TestAgentRun_StatusRunning(t *testing.T) {
 
 func TestAgentRun_ReadinessProbe(t *testing.T) {
 	dir, _ := ioutil.TempDir("", "mackerel-container-agent-run-test-readiness-probe")
-	defer os.Remove(dir)
+	defer os.RemoveAll(dir)
 	conf := &config.Config{
 		Root: dir,
 		ReadinessProbe: &config.Probe{
@@ -667,7 +667,7 @@ func TestAgentRun_ReadinessProbe(t *testing.T) {
 
 func TestAgentRun_ReadinessProbe_SleepLong(t *testing.T) {
 	dir, _ := ioutil.TempDir("", "mackerel-container-agent-run-test-readiness-probe-sleep-long")
-	defer os.Remove(dir)
+	defer os.RemoveAll(dir)
 	conf := &config.Config{
 		Root: dir,
 		ReadinessProbe: &config.Probe{
@@ -695,7 +695,7 @@ func TestAgentRun_ReadinessProbe_SleepLong(t *testing.T) {
 
 func TestAgentRun_HostStatusOnStart(t *testing.T) {
 	dir, _ := ioutil.TempDir("", "mackerel-container-agent-run-test-host-status-on-start")
-	defer os.Remove(dir)
+	defer os.RemoveAll(dir)
 	conf := &config.Config{
 		Root:              dir,
 		HostStatusOnStart: mackerel.HostStatusWorking,


### PR DESCRIPTION
We should use os.RemoveAll to remove the test directories.