### PR TITLE
Release version 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.2.0 (2019-07-16)
+
+* add mackerel-plugin-json to Docker image #51 (hayajo)
+* Delay host retirement for hangup signal and config reload #49 (itchyny)
+* Implement polling duration for reloading agent config #47 (itchyny)
+* Fix missing region error when using S3 for config path #46 (hayajo)
+
+
 ## 0.1.0 (2019-06-12)
 
 * integrate ECS platforms #43 (hayajo)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 BIN := mackerel-container-agent
-VERSION := 0.1.0
+VERSION := 0.2.0
 REVISION := $(shell git rev-parse --short HEAD)
 
 export GO111MODULE=on


### PR DESCRIPTION
- add mackerel-plugin-json to Docker image #51
- Delay host retirement for hangup signal and config reload #49
- Implement polling duration for reloading agent config #47
- Fix missing region error when using S3 for config path #46