### PR TITLE
Fix typo: crated_at -> created_at

### DIFF
--- a/platform/ecs/types.go
+++ b/platform/ecs/types.go
@@ -29,7 +29,7 @@ type containerSpec struct {
 	KnownStatus   string            `json:"known_status,omitempty"`
 	ExitCode      *int              `json:"exit_code,omitempty"`
 	Limits        limitSpec         `json:"limits,omitempty"`
-	CreatedAt     *time.Time        `json:"crated_at,omitempty"`
+	CreatedAt     *time.Time        `json:"created_at,omitempty"`
 	StartedAt     *time.Time        `json:"started_at,omitempty"`
 	FinishedAt    *time.Time        `json:"finished_at,omitempty"`
 	Type          string            `json:"type,omitempty"`


### PR DESCRIPTION
`CreatedAt` field is encoded as `crated_at` in JSON but it will be expected as `created_at` (and maybe typo).