### PR TITLE
fix config reload interrupts collecting metrics / check reports

### DIFF
--- a/check/manager.go
+++ b/check/manager.go
@@ -43,8 +43,7 @@ loop:
 			break loop
 		case <-t.C:
 			go func() {
-				d := time.Now().Add(time.Minute)
-				ctx, cancel := context.WithDeadline(context.Background(), d)
+				ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 				defer cancel()
 				if err := m.collectAndPostCheckReports(ctx); err != nil {
 					errCh <- err

--- a/check/manager.go
+++ b/check/manager.go
@@ -43,7 +43,7 @@ loop:
 			break loop
 		case <-t.C:
 			go func() {
-				if err := m.collectAndPostCheckReports(ctx); err != nil {
+				if err := m.collectAndPostCheckReports(context.Background()); err != nil {
 					errCh <- err
 				}
 			}()

--- a/check/manager.go
+++ b/check/manager.go
@@ -43,7 +43,10 @@ loop:
 			break loop
 		case <-t.C:
 			go func() {
-				if err := m.collectAndPostCheckReports(context.Background()); err != nil {
+				d := time.Now().Add(time.Minute)
+				ctx, cancel := context.WithDeadline(context.Background(), d)
+				defer cancel()
+				if err := m.collectAndPostCheckReports(ctx); err != nil {
 					errCh <- err
 				}
 			}()

--- a/metric/manager.go
+++ b/metric/manager.go
@@ -38,7 +38,7 @@ loop:
 			break loop
 		case <-t.C:
 			go func() {
-				if err := m.collectAndPostValues(ctx); err != nil {
+				if err := m.collectAndPostValues(context.Background()); err != nil {
 					errCh <- err
 				}
 			}()

--- a/metric/manager.go
+++ b/metric/manager.go
@@ -38,7 +38,10 @@ loop:
 			break loop
 		case <-t.C:
 			go func() {
-				if err := m.collectAndPostValues(context.Background()); err != nil {
+				d := time.Now().Add(time.Minute)
+				ctx, cancel := context.WithDeadline(context.Background(), d)
+				defer cancel()
+				if err := m.collectAndPostValues(ctx); err != nil {
 					errCh <- err
 				}
 			}()

--- a/metric/manager.go
+++ b/metric/manager.go
@@ -38,8 +38,7 @@ loop:
 			break loop
 		case <-t.C:
 			go func() {
-				d := time.Now().Add(time.Minute)
-				ctx, cancel := context.WithDeadline(context.Background(), d)
+				ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 				defer cancel()
 				if err := m.collectAndPostValues(ctx); err != nil {
 					errCh <- err


### PR DESCRIPTION
When the agent reloads configuration, it cancels the current context before restarting itself.
However, metric / check report collections are also referring to that context and can be interrupted, which causes the agent to lose some metric data points and/or report UNKNOWN status.

This PR fixes it by separating contexts for the agent itself and metric / check report collections to avoid interruptions on config reload.

Edit: This also keeps metric collections alive when the agent is stoped by other reasons (like SIGTERM).
