### PR TITLE
add "none" platform

### DIFF
--- a/agent/platform.go
+++ b/agent/platform.go
@@ -90,6 +90,7 @@ func NewPlatform(ctx context.Context, ignoreContainer *regexp.Regexp) (platform.
 		}
 		return kubernetes.NewEKSOnFargatePlatform(host, port, namespace, podName, nodeName, ignoreContainer)
 
+	// for testing & debugging on local machine
 	case platform.None:
 		return none.NewNonePlatform()
 

--- a/agent/platform.go
+++ b/agent/platform.go
@@ -11,6 +11,7 @@ import (
 	"github.com/mackerelio/mackerel-container-agent/platform/ecs"
 	"github.com/mackerelio/mackerel-container-agent/platform/kubernetes"
 	"github.com/mackerelio/mackerel-container-agent/platform/kubernetes/kubelet"
+	"github.com/mackerelio/mackerel-container-agent/platform/none"
 )
 
 // NewPlatform creates a new container platform
@@ -88,6 +89,9 @@ func NewPlatform(ctx context.Context, ignoreContainer *regexp.Regexp) (platform.
 			return nil, err
 		}
 		return kubernetes.NewEKSOnFargatePlatform(host, port, namespace, podName, nodeName, ignoreContainer)
+
+	case platform.None:
+		return none.NewNonePlatform()
 
 	default:
 		return nil, errors.New("platform not specified")

--- a/platform/none/none.go
+++ b/platform/none/none.go
@@ -1,0 +1,32 @@
+package none
+
+import (
+	"context"
+
+	"github.com/mackerelio/mackerel-container-agent/metric"
+	"github.com/mackerelio/mackerel-container-agent/platform"
+	"github.com/mackerelio/mackerel-container-agent/spec"
+)
+
+type nonePlatform struct{}
+
+// NewNonePlatform creates a new Platform
+func NewNonePlatform() (platform.Platform, error) {
+	return &nonePlatform{}, nil
+}
+
+func (p *nonePlatform) GetMetricGenerators() []metric.Generator {
+	return []metric.Generator{}
+}
+
+func (p *nonePlatform) GetSpecGenerators() []spec.Generator {
+	return []spec.Generator{}
+}
+
+func (p *nonePlatform) GetCustomIdentifier(context.Context) (string, error) {
+	return "", nil
+}
+
+func (p *nonePlatform) StatusRunning(context.Context) bool {
+	return true
+}

--- a/platform/types.go
+++ b/platform/types.go
@@ -11,4 +11,5 @@ const (
 	Fargate      Type = "fargate"
 	Kubernetes   Type = "kubernetes"
 	EKSOnFargate Type = "eks_fargate"
+	None         Type = "none"
 )


### PR DESCRIPTION
NOTE: This is only for development of container-agent itself.

Add "none" platform, which does not collect any platform-specific data such as specs and metrics of containers.

Currently testing & debugging container-agent requires platform setups, and it takes a bit time and efforts.
Using "none" platform enables us to test & debug non-platform-specific features quickly, even on local machine.
