### PR TITLE
Fallback to Kubernetes Node API when Kubelet Spec API is not available

### DIFF
--- a/platform/kubernetes/kubelet/client.go
+++ b/platform/kubernetes/kubelet/client.go
@@ -143,7 +143,7 @@ func (c *client) GetPodStats(ctx context.Context) (*kubeletTypes.PodStats, error
 var ErrNotFound = errors.New("http not found")
 
 // GetPodStats gets pod spec
-// NOTICE: this API is deprecated and will be removed in Kubernetes 1.20
+// Deprecated: this API is deprecated in Kubernetes 1.18 (and disabled by default), and will be removed in Kubernetes 1.20
 func (c *client) GetSpec(ctx context.Context) (*cadvisorTypes.MachineInfo, error) {
 	req, err := c.newRequest(specPath)
 	if err != nil {

--- a/platform/kubernetes/kubelet/client.go
+++ b/platform/kubernetes/kubelet/client.go
@@ -139,6 +139,7 @@ func (c *client) GetPodStats(ctx context.Context) (*kubeletTypes.PodStats, error
 }
 
 // GetPodStats gets pod spec
+// NOTICE: this API is deprecated and will be removed in Kubernetes 1.20
 func (c *client) GetSpec(ctx context.Context) (*cadvisorTypes.MachineInfo, error) {
 	req, err := c.newRequest(specPath)
 	if err != nil {

--- a/platform/kubernetes/kubelet/client.go
+++ b/platform/kubernetes/kubelet/client.go
@@ -3,6 +3,7 @@ package kubelet
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -139,7 +140,7 @@ func (c *client) GetPodStats(ctx context.Context) (*kubeletTypes.PodStats, error
 }
 
 // ErrNotFound shows that underlying HTTP request was 404 Not found
-var ErrNotFound error
+var ErrNotFound = errors.New("http not found")
 
 // GetPodStats gets pod spec
 // NOTICE: this API is deprecated and will be removed in Kubernetes 1.20

--- a/platform/kubernetes/kubelet/client.go
+++ b/platform/kubernetes/kubelet/client.go
@@ -138,6 +138,9 @@ func (c *client) GetPodStats(ctx context.Context) (*kubeletTypes.PodStats, error
 	return stats, nil
 }
 
+// ErrNotFound shows that underlying HTTP request was 404 Not found
+var ErrNotFound error
+
 // GetPodStats gets pod spec
 // NOTICE: this API is deprecated and will be removed in Kubernetes 1.20
 func (c *client) GetSpec(ctx context.Context) (*cadvisorTypes.MachineInfo, error) {
@@ -148,6 +151,9 @@ func (c *client) GetSpec(ctx context.Context) (*cadvisorTypes.MachineInfo, error
 	resp, err := c.httpClient.Do(req.WithContext(ctx))
 	if err != nil {
 		return nil, err
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, ErrNotFound
 	}
 	var info cadvisorTypes.MachineInfo
 	if err = decodeBody(resp, &info); err != nil {

--- a/platform/kubernetes/kubelet/client_test.go
+++ b/platform/kubernetes/kubelet/client_test.go
@@ -173,6 +173,28 @@ func TestGetSpec(t *testing.T) {
 	}
 }
 
+func TestGetSpec_NotFound(t *testing.T) {
+	token := "foobar"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if token != "" && r.Header.Get("Authorization") != "Bearer "+token {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+
+	ctx := context.Background()
+	defer ts.Close()
+	c, err := NewClient(ts.Client(), token, ts.URL, "default", "myapp", nil)
+	if err != nil {
+		t.Errorf("should not raise error: %v", err)
+	}
+	_, err = c.GetSpec(ctx)
+	if err != ErrNotFound {
+		t.Errorf("GetSpec() should raise ErrNotFound error: %v", err)
+	}
+}
+
 func TestIgnoreContainer(t *testing.T) {
 	ts := newServer("")
 	defer ts.Close()

--- a/platform/kubernetes/kubernetes.go
+++ b/platform/kubernetes/kubernetes.go
@@ -145,7 +145,7 @@ func NewEKSOnFargatePlatform(kubernetesServiceHost, kubernetesServicePort string
 // GetMetricGenerators gets metric generators
 func (p *kubernetesPlatform) GetMetricGenerators() []metric.Generator {
 	return []metric.Generator{
-		newMetricGenerator(p.client),
+		newMetricGenerator(p.client, p.apiClient),
 		metric.NewInterfaceGenerator(),
 	}
 }

--- a/platform/kubernetes/kubernetes.go
+++ b/platform/kubernetes/kubernetes.go
@@ -8,7 +8,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"path"
 	"regexp"
 	"strings"
 	"time"
@@ -99,13 +98,6 @@ func NewEKSOnFargatePlatform(kubernetesServiceHost, kubernetesServicePort string
 		Host:   net.JoinHostPort(kubernetesServiceHost, kubernetesServicePort),
 	}
 
-	// Access to kubelet via /api/v1/nodes/{nodeName}/proxy
-	kubeletBaseURL := &url.URL{
-		Scheme: "https",
-		Host:   net.JoinHostPort(kubernetesServiceHost, kubernetesServicePort),
-		Path:   path.Join("api", "v1", "nodes", nodeName, "proxy"),
-	}
-
 	caCert, err = ioutil.ReadFile(caCertificateFile)
 	if err != nil {
 		return nil, err
@@ -128,6 +120,8 @@ func NewEKSOnFargatePlatform(kubernetesServiceHost, kubernetesServicePort string
 		return nil, err
 	}
 
+	// access kubelet via proxy
+	kubeletBaseURL := sc.NodeProxyURL()
 	c, err := kubelet.NewClient(
 		httpClient,
 		string(token),

--- a/platform/kubernetes/kubernetes.go
+++ b/platform/kubernetes/kubernetes.go
@@ -75,13 +75,14 @@ func NewKubernetesPlatform(kubeletHost, kubeletPort string, useReadOnlyPort, ins
 }
 
 // NewEKSOnFargatePlatform creates a new Platform
-func NewEKSOnFargatePlatform(kubeletHost, kubeletPort string, namespace, podName string, nodeName string, ignoreContainer *regexp.Regexp) (platform.Platform, error) {
+func NewEKSOnFargatePlatform(kubernetesServiceHost, kubernetesServicePort string, namespace, podName string, nodeName string, ignoreContainer *regexp.Regexp) (platform.Platform, error) {
 	var caCert, token []byte
 	var err error
 
+	// Access to kubelet via /api/v1/nodes/{nodeName}/proxy
 	baseURL := &url.URL{
 		Scheme: "https",
-		Host:   net.JoinHostPort(kubeletHost, kubeletPort),
+		Host:   net.JoinHostPort(kubernetesServiceHost, kubernetesServicePort),
 		Path:   path.Join("api", "v1", "nodes", nodeName, "proxy"),
 	}
 

--- a/platform/kubernetes/kubernetes.go
+++ b/platform/kubernetes/kubernetes.go
@@ -70,18 +70,16 @@ func NewKubernetesPlatform(kubernetesServiceHost, kubernetesServicePort, kubelet
 	if err != nil {
 		if !useReadOnlyPort {
 			return nil, err
-		} else {
-			logger.Warningf("failed to read service account certification file, %w", err)
 		}
+		logger.Warningf("failed to read service account certification file, %w", err)
 	}
 
 	token, err = ioutil.ReadFile(tokenFile)
 	if err != nil {
 		if !useReadOnlyPort {
 			return nil, err
-		} else {
-			logger.Warningf("failed to read service account token file, %w", err)
 		}
+		logger.Warningf("failed to read service account token file, %w", err)
 	}
 
 	httpClient := createHTTPClient(caCert, insecureTLS)

--- a/platform/kubernetes/kubernetes_test.go
+++ b/platform/kubernetes/kubernetes_test.go
@@ -16,7 +16,9 @@ import (
 
 func TestStatusRunning(t *testing.T) {
 	mockClient := kubelet.NewMockClient()
-	pform := kubernetesPlatform{mockClient}
+	pform := kubernetesPlatform{
+		client: mockClient,
+	}
 
 	tests := []struct {
 		status string

--- a/platform/kubernetes/kubernetesapi/client.go
+++ b/platform/kubernetes/kubernetesapi/client.go
@@ -15,6 +15,7 @@ import (
 // Client interface gets metadata and stats
 type Client interface {
 	GetNode(context.Context) (*kubernetesTypes.Node, error)
+	NodeProxyURL() *url.URL
 }
 
 const (
@@ -41,6 +42,15 @@ func NewClient(httpClient *http.Client, token, baseURL, nodeName string) (Client
 		token:      token,
 		nodeName:   nodeName,
 	}, nil
+}
+
+// NodeProxyURL returns url which can be used for kubelet base url
+func (c *client) NodeProxyURL() *url.URL {
+	return &url.URL{
+		Scheme: "https",
+		Host:   c.url.Host,
+		Path:   path.Join(basePath, nodePath, c.nodeName, "proxy"),
+	}
 }
 
 // GetNode gets node spec

--- a/platform/kubernetes/kubernetesapi/client.go
+++ b/platform/kubernetes/kubernetesapi/client.go
@@ -1,0 +1,83 @@
+package kubernetesapi
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"path"
+
+	kubernetesTypes "k8s.io/api/core/v1"
+)
+
+// Client interface gets metadata and stats
+type Client interface {
+	GetNode(context.Context) (*kubernetesTypes.Node, error)
+}
+
+const (
+	basePath = "/api/v1"
+	nodePath = "/nodes/"
+)
+
+type client struct {
+	url        *url.URL
+	httpClient *http.Client
+	nodeName   string
+	token      string
+}
+
+// NewClient creates a new Client
+func NewClient(httpClient *http.Client, token, baseURL, nodeName string) (Client, error) {
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, err
+	}
+	return &client{
+		url:        u,
+		httpClient: httpClient,
+		token:      token,
+		nodeName:   nodeName,
+	}, nil
+}
+
+// GetNode gets node spec
+func (c *client) GetNode(ctx context.Context) (*kubernetesTypes.Node, error) {
+	req, err := c.newRequest(nodePath + c.nodeName)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.httpClient.Do(req.WithContext(ctx))
+	if err != nil {
+		return nil, err
+	}
+	var node kubernetesTypes.Node
+	if err = decodeBody(resp, &node); err != nil {
+		return nil, err
+	}
+	return &node, err
+}
+
+func (c *client) newRequest(endpoint string) (*http.Request, error) {
+	u := *c.url
+	u.Path = path.Join(c.url.Path, basePath, endpoint)
+	req, err := http.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	if c.token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
+	return req, nil
+}
+
+func decodeBody(resp *http.Response, out interface{}) error {
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := ioutil.ReadAll(resp.Body)
+		return fmt.Errorf("got status code %d (url: %s, body: %q)", resp.StatusCode, resp.Request.URL, body)
+	}
+	return json.NewDecoder(resp.Body).Decode(out)
+}

--- a/platform/kubernetes/kubernetesapi/client_test.go
+++ b/platform/kubernetes/kubernetesapi/client_test.go
@@ -17,7 +17,6 @@ func newServer(token string) *httptest.Server {
 			w.WriteHeader(http.StatusUnauthorized)
 			return
 		}
-		fmt.Println(r.URL.RequestURI())
 		// only /api/v1/nodes/VALID-NODE is valid
 		switch r.URL.RequestURI() {
 		case validNodePath:

--- a/platform/kubernetes/kubernetesapi/client_test.go
+++ b/platform/kubernetes/kubernetesapi/client_test.go
@@ -1,0 +1,102 @@
+package kubernetesapi
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path"
+	"testing"
+)
+
+func newServer(token string) *httptest.Server {
+	validNodePath := path.Join(basePath, nodePath, "VALID-NODE")
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if token != "" && r.Header.Get("Authorization") != "Bearer "+token {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		fmt.Println(r.URL.RequestURI())
+		// only /api/v1/nodes/VALID-NODE is valid
+		switch r.URL.RequestURI() {
+		case validNodePath:
+			http.ServeFile(w, r, "testdata/node.json")
+		}
+	})
+	return httptest.NewServer(handler)
+}
+
+func TestGetNode(t *testing.T) {
+	ctx := context.Background()
+	ts := newServer("")
+	defer ts.Close()
+	c, err := NewClient(ts.Client(), "", ts.URL, "VALID-NODE")
+	if err != nil {
+		t.Errorf("should not raise error: %v", err)
+	}
+	_, err = c.GetNode(ctx)
+	if err != nil {
+		t.Errorf("GetNode() should not raise error: %v", err)
+	}
+}
+
+func TestRequestToken(t *testing.T) {
+	testToken := "testToken"
+
+	ts := newServer(testToken)
+	defer ts.Close()
+
+	ctx := context.Background()
+	c, err := NewClient(ts.Client(), testToken, ts.URL, "VALID-NODE")
+	if err != nil {
+		t.Errorf("NewClient() should not raise error: %v", err)
+	}
+
+	_, err = c.GetNode(ctx)
+	if err != nil {
+		t.Errorf("newRequest() should not raise error: %v", err)
+	}
+}
+
+func TestErrorMessage(t *testing.T) {
+	var body string
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(body))
+	})
+	ts := httptest.NewServer(handler)
+
+	c, err := NewClient(ts.Client(), "", ts.URL, "some-node")
+	if err != nil {
+		t.Errorf("should not raise error: %v", err)
+	}
+
+	tests := []struct {
+		body string
+	}{
+		{"Bad Request"},
+		{"Bad\nRequest"},
+	}
+
+	for _, tc := range tests {
+		body = tc.body
+
+		ctx := context.Background()
+
+		_, err = c.GetNode(ctx)
+		if err == nil {
+			t.Errorf("should raise error")
+		}
+
+		u, _ := url.Parse(ts.URL)
+		u.Path = path.Join(u.Path, basePath, nodePath, "some-node")
+		expected := fmt.Sprintf("got status code %d (url: %s, body: %q)", http.StatusBadRequest, u, tc.body)
+
+		got := err.Error()
+		if got != expected {
+			t.Errorf("error message expected %q, got %q", expected, got)
+		}
+	}
+}

--- a/platform/kubernetes/kubernetesapi/mock_client.go
+++ b/platform/kubernetes/kubernetesapi/mock_client.go
@@ -1,0 +1,67 @@
+package kubernetesapi
+
+import (
+	"context"
+	"net/url"
+
+	kubernetesTypes "k8s.io/api/core/v1"
+)
+
+// MockClient represents a mock client of Kubernetes APIs
+type MockClient struct {
+	getNodeCallback      func(context.Context) (*kubernetesTypes.Node, error)
+	nodeProxyURLCallback func() *url.URL
+}
+
+// MockClientOption represents an option of mock client of Kubernetes APIs
+type MockClientOption func(*MockClient)
+
+// NewMockClient creates a new mock client of Kubernetes APIs
+func NewMockClient(opts ...MockClientOption) *MockClient {
+	c := &MockClient{}
+	for _, o := range opts {
+		c.ApplyOption(o)
+	}
+	return c
+}
+
+// ApplyOption applies a mock client option
+func (c *MockClient) ApplyOption(opt MockClientOption) {
+	opt(c)
+}
+
+type errCallbackNotFound string
+
+func (err errCallbackNotFound) Error() string {
+	return string(err) + " callback not found"
+}
+
+// GetNode ...
+func (c *MockClient) GetNode(ctx context.Context) (*kubernetesTypes.Node, error) {
+	if c.getNodeCallback != nil {
+		return c.getNodeCallback(ctx)
+	}
+	return nil, errCallbackNotFound("GetNode")
+}
+
+// MockGetNode returns an option to set the callback of GetNode
+func MockGetNode(callback func(context.Context) (*kubernetesTypes.Node, error)) MockClientOption {
+	return func(c *MockClient) {
+		c.getNodeCallback = callback
+	}
+}
+
+// NodeProxyURL ...
+func (c *MockClient) NodeProxyURL() *url.URL {
+	if c.nodeProxyURLCallback != nil {
+		return c.nodeProxyURLCallback()
+	}
+	return nil
+}
+
+// MockNodeProxyURL returns an option to set the callback of NodeProxyURL
+func MockNodeProxyURL(callback func() *url.URL) MockClientOption {
+	return func(c *MockClient) {
+		c.nodeProxyURLCallback = callback
+	}
+}

--- a/platform/kubernetes/kubernetesapi/testdata/node.json
+++ b/platform/kubernetes/kubernetesapi/testdata/node.json
@@ -1,0 +1,370 @@
+{
+    "kind": "Node",
+    "apiVersion": "v1",
+    "metadata": {
+        "name": "DUMMYCLUST-default-pool-3cfec336-66qg",
+        "selfLink": "/api/v1/nodes/DUMMYCLUST-default-pool-3cfec336-66qg",
+        "uid": "7fc0bda4-c6c5-4560-8478-ce64d97b3d70",
+        "resourceVersion": "407613",
+        "creationTimestamp": "2020-10-13T10:39:37Z",
+        "labels": {
+            "beta.kubernetes.io/arch": "amd64",
+            "beta.kubernetes.io/instance-type": "n1-standard-1",
+            "beta.kubernetes.io/os": "linux",
+            "cloud.google.com/gke-nodepool": "default-pool",
+            "cloud.google.com/gke-os-distribution": "cos",
+            "failure-domain.beta.kubernetes.io/region": "asia-northeast1",
+            "failure-domain.beta.kubernetes.io/zone": "asia-northeast1-a",
+            "kubernetes.io/arch": "amd64",
+            "kubernetes.io/hostname": "DUMMYCLUST-default-pool-3cfec336-66qg",
+            "kubernetes.io/os": "linux"
+        },
+        "annotations": {
+            "container.googleapis.com/instance_id": "8252331636212383157",
+            "node.alpha.kubernetes.io/ttl": "0",
+            "node.gke.io/last-applied-node-labels": "cloud.google.com/gke-nodepool=default-pool,cloud.google.com/gke-os-distribution=cos",
+            "volumes.kubernetes.io/controller-managed-attach-detach": "true"
+        }
+    },
+    "spec": {
+        "podCIDR": "10.52.0.0/24",
+        "podCIDRs": [
+            "10.52.0.0/24"
+        ],
+        "providerID": "gce://DUMMYPROJ/asia-northeast1-a/DUMMYCLUST-default-pool-3cfec336-66qg"
+    },
+    "status": {
+        "capacity": {
+            "attachable-volumes-gce-pd": "127",
+            "cpu": "1",
+            "ephemeral-storage": "98868448Ki",
+            "hugepages-2Mi": "0",
+            "memory": "3785940Ki",
+            "pods": "110"
+        },
+        "allocatable": {
+            "attachable-volumes-gce-pd": "127",
+            "cpu": "940m",
+            "ephemeral-storage": "47093746742",
+            "hugepages-2Mi": "0",
+            "memory": "2700500Ki",
+            "pods": "110"
+        },
+        "conditions": [
+            {
+                "type": "FrequentContainerdRestart",
+                "status": "False",
+                "lastHeartbeatTime": "2020-10-14T14:28:03Z",
+                "lastTransitionTime": "2020-10-13T10:39:39Z",
+                "reason": "NoFrequentContainerdRestart",
+                "message": "containerd is functioning properly"
+            },
+            {
+                "type": "CorruptDockerOverlay2",
+                "status": "False",
+                "lastHeartbeatTime": "2020-10-14T14:28:03Z",
+                "lastTransitionTime": "2020-10-13T10:39:39Z",
+                "reason": "NoCorruptDockerOverlay2",
+                "message": "docker overlay2 is functioning properly"
+            },
+            {
+                "type": "KernelDeadlock",
+                "status": "False",
+                "lastHeartbeatTime": "2020-10-14T14:28:03Z",
+                "lastTransitionTime": "2020-10-13T10:39:39Z",
+                "reason": "KernelHasNoDeadlock",
+                "message": "kernel has no deadlock"
+            },
+            {
+                "type": "ReadonlyFilesystem",
+                "status": "False",
+                "lastHeartbeatTime": "2020-10-14T14:28:03Z",
+                "lastTransitionTime": "2020-10-13T10:39:39Z",
+                "reason": "FilesystemIsNotReadOnly",
+                "message": "Filesystem is not read-only"
+            },
+            {
+                "type": "FrequentUnregisterNetDevice",
+                "status": "False",
+                "lastHeartbeatTime": "2020-10-14T14:28:03Z",
+                "lastTransitionTime": "2020-10-13T10:39:39Z",
+                "reason": "NoFrequentUnregisterNetDevice",
+                "message": "node is functioning properly"
+            },
+            {
+                "type": "FrequentKubeletRestart",
+                "status": "False",
+                "lastHeartbeatTime": "2020-10-14T14:28:03Z",
+                "lastTransitionTime": "2020-10-13T10:39:39Z",
+                "reason": "NoFrequentKubeletRestart",
+                "message": "kubelet is functioning properly"
+            },
+            {
+                "type": "FrequentDockerRestart",
+                "status": "False",
+                "lastHeartbeatTime": "2020-10-14T14:28:03Z",
+                "lastTransitionTime": "2020-10-13T10:39:39Z",
+                "reason": "NoFrequentDockerRestart",
+                "message": "docker is functioning properly"
+            },
+            {
+                "type": "NetworkUnavailable",
+                "status": "False",
+                "lastHeartbeatTime": "2020-10-13T10:39:56Z",
+                "lastTransitionTime": "2020-10-13T10:39:56Z",
+                "reason": "RouteCreated",
+                "message": "RouteController created a route"
+            },
+            {
+                "type": "MemoryPressure",
+                "status": "False",
+                "lastHeartbeatTime": "2020-10-14T14:29:10Z",
+                "lastTransitionTime": "2020-10-13T10:39:37Z",
+                "reason": "KubeletHasSufficientMemory",
+                "message": "kubelet has sufficient memory available"
+            },
+            {
+                "type": "DiskPressure",
+                "status": "False",
+                "lastHeartbeatTime": "2020-10-14T14:29:10Z",
+                "lastTransitionTime": "2020-10-13T10:39:37Z",
+                "reason": "KubeletHasNoDiskPressure",
+                "message": "kubelet has no disk pressure"
+            },
+            {
+                "type": "PIDPressure",
+                "status": "False",
+                "lastHeartbeatTime": "2020-10-14T14:29:10Z",
+                "lastTransitionTime": "2020-10-13T10:39:37Z",
+                "reason": "KubeletHasSufficientPID",
+                "message": "kubelet has sufficient PID available"
+            },
+            {
+                "type": "Ready",
+                "status": "True",
+                "lastHeartbeatTime": "2020-10-14T14:29:10Z",
+                "lastTransitionTime": "2020-10-13T10:39:37Z",
+                "reason": "KubeletReady",
+                "message": "kubelet is posting ready status. AppArmor enabled"
+            }
+        ],
+        "addresses": [
+            {
+                "type": "InternalIP",
+                "address": "10.146.0.31"
+            },
+            {
+                "type": "ExternalIP",
+                "address": "8.8.8.8"
+            },
+            {
+                "type": "InternalDNS",
+                "address": "DUMMYCLUST-default-pool-3cfec336-66qg.c.DUMMYPROJ.internal"
+            },
+            {
+                "type": "Hostname",
+                "address": "DUMMYCLUST-default-pool-3cfec336-66qg.c.DUMMYPROJ.internal"
+            }
+        ],
+        "daemonEndpoints": {
+            "kubeletEndpoint": {
+                "Port": 10250
+            }
+        },
+        "nodeInfo": {
+            "machineID": "9438b60edd33f94c569e2999d7f72f29",
+            "systemUUID": "9438b60e-dd33-f94c-569e-2999d7f72f29",
+            "bootID": "fd72ad1c-408f-4b1c-a04d-8505dfbafe7b",
+            "kernelVersion": "4.19.112+",
+            "osImage": "Container-Optimized OS from Google",
+            "containerRuntimeVersion": "docker://19.3.1",
+            "kubeletVersion": "v1.16.13-gke.401",
+            "kubeProxyVersion": "v1.16.13-gke.401",
+            "operatingSystem": "linux",
+            "architecture": "amd64"
+        },
+        "images": [
+            {
+                "names": [
+                    "gcr.io/stackdriver-agents/stackdriver-logging-agent@sha256:e2ef6735a2730d3af25a2bdca6ecbcfc80a2d25f4aaf69cc25c4af9b56b39996",
+                    "gcr.io/stackdriver-agents/stackdriver-logging-agent:1.6.36"
+                ],
+                "sizeBytes": 223205783
+            },
+            {
+                "names": [
+                    "k8s.gcr.io/kubernetes-dashboard-amd64@sha256:0ae6b69432e78069c5ce2bcde0fe409c5c4d6f0f4d9cd50a17974fea38898747",
+                    "k8s.gcr.io/kubernetes-dashboard-amd64:v1.10.1"
+                ],
+                "sizeBytes": 121711221
+            },
+            {
+                "names": [
+                    "gke.gcr.io/kube-proxy-amd64:v1.16.13-gke.401",
+                    "k8s.gcr.io/kube-proxy-amd64:v1.16.13-gke.401"
+                ],
+                "sizeBytes": 117678303
+            },
+            {
+                "names": [
+                    "k8s.gcr.io/node-problem-detector@sha256:7101cdf7a2fc05facbc39cd9c03c195cbbdbd7eb99efadb45d94473f4e29fe0c",
+                    "k8s.gcr.io/node-problem-detector:v0.7.1"
+                ],
+                "sizeBytes": 100104055
+            },
+            {
+                "names": [
+                    "gke.gcr.io/k8s-dns-kube-dns-amd64@sha256:aa806fb62da0318362fe5a8b110187cfc99f41c6c14261855fa10e1680f60d5b",
+                    "gke.gcr.io/k8s-dns-kube-dns-amd64:1.15.13"
+                ],
+                "sizeBytes": 97549250
+            },
+            {
+                "names": [
+                    "gcr.io/gke-release/gke-metrics-agent@sha256:9ba59e40ac1bccf7fce37903a3ef51d865d376f46907d7667f2e8b79d839ef58",
+                    "gcr.io/gke-release/gke-metrics-agent:0.1.3-gke.0"
+                ],
+                "sizeBytes": 90931272
+            },
+            {
+                "names": [
+                    "mackerel/mackerel-container-agent@sha256:1950b83fa7b9e80f5fee42be8e94840ffedf8bba8ff0f44e344b070f921b412e",
+                    "mackerel/mackerel-container-agent:latest"
+                ],
+                "sizeBytes": 90639293
+            },
+            {
+                "names": [
+                    "k8s.gcr.io/fluentd-gcp-scaler@sha256:4f28f10fb89506768910b858f7a18ffb996824a16d70d5ac895e49687df9ff58",
+                    "k8s.gcr.io/fluentd-gcp-scaler:0.5.2"
+                ],
+                "sizeBytes": 90498960
+            },
+            {
+                "names": [
+                    "gke.gcr.io/k8s-dns-sidecar-amd64@sha256:2c935daf0ee19f45d04c44a19a82bfd21c3d960fe286df970dce491fd8e8b0b5",
+                    "gke.gcr.io/k8s-dns-sidecar-amd64:1.15.13"
+                ],
+                "sizeBytes": 89831490
+            },
+            {
+                "names": [
+                    "gke.gcr.io/k8s-dns-dnsmasq-nanny-amd64@sha256:1eba77c751b7b25c9af97c23c857f3a7024253224d256b8648b0d86cddda5074",
+                    "gke.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.15.13"
+                ],
+                "sizeBytes": 87716493
+            },
+            {
+                "names": [
+                    "k8s.gcr.io/kube-addon-manager@sha256:3e315022a842d782a28e729720f21091dde21f1efea28868d65ec595ad871616",
+                    "k8s.gcr.io/kube-addon-manager:v9.0.2"
+                ],
+                "sizeBytes": 83076028
+            },
+            {
+                "names": [
+                    "gke.gcr.io/event-exporter@sha256:6c08dc79478246a7cf9b7f7242dbc6ab0fdde2610b346db06faac69ec548d4f2",
+                    "gke.gcr.io/event-exporter:v0.3.3-gke.0"
+                ],
+                "sizeBytes": 76859593
+            },
+            {
+                "names": [
+                    "k8s.gcr.io/heapster-amd64@sha256:9fae0af136ce0cf4f88393b3670f7139ffc464692060c374d2ae748e13144521",
+                    "k8s.gcr.io/heapster-amd64:v1.6.0-beta.1"
+                ],
+                "sizeBytes": 76016169
+            },
+            {
+                "names": [
+                    "gke.gcr.io/prometheus-to-sd@sha256:c5e12680a431990d5e39ed249dcb43a7672e99f7ef94a9928be40cf2f418f62f",
+                    "gke.gcr.io/prometheus-to-sd:v0.10.0-gke.0"
+                ],
+                "sizeBytes": 72131547
+            },
+            {
+                "names": [
+                    "k8s.gcr.io/ingress-gce-glbc-amd64@sha256:14f14351a03038b238232e60850a9cfa0dffbed0590321ef84216a432accc1ca",
+                    "k8s.gcr.io/ingress-gce-glbc-amd64:v1.2.3"
+                ],
+                "sizeBytes": 71797285
+            },
+            {
+                "names": [
+                    "k8s.gcr.io/k8s-dns-node-cache@sha256:1a51ef8f60a3ffdc5dd128ce270588ffaf2bc4119ec48d5f917d0d3ad777bd23",
+                    "k8s.gcr.io/k8s-dns-node-cache:1.15.3"
+                ],
+                "sizeBytes": 62534058
+            },
+            {
+                "names": [
+                    "gcr.io/stackdriver-agents/metadata-agent-go@sha256:b7d97f6543ebd8d133da944f3631cc2501c16dbc2abc835e741f4dcc8daba3d7",
+                    "gcr.io/stackdriver-agents/metadata-agent-go:1.2.0"
+                ],
+                "sizeBytes": 55482425
+            },
+            {
+                "names": [
+                    "k8s.gcr.io/k8s-dns-kube-dns@sha256:c54a527a4ba8f1bc15e4796b09bf5d69313c7f42af9911dc437e056c0264a2fe",
+                    "k8s.gcr.io/k8s-dns-kube-dns:1.14.13"
+                ],
+                "sizeBytes": 51157394
+            },
+            {
+                "names": [
+                    "asia.gcr.io/gke-release-staging/addon-resizer@sha256:c345bde227f83897cf37c0dd0faadcbba60cad013671ccf9b2a49b0342560043",
+                    "eu.gcr.io/gke-release-staging/addon-resizer@sha256:c345bde227f83897cf37c0dd0faadcbba60cad013671ccf9b2a49b0342560043",
+                    "gcr.io/gke-release-staging/addon-resizer@sha256:c345bde227f83897cf37c0dd0faadcbba60cad013671ccf9b2a49b0342560043",
+                    "asia.gcr.io/gke-release-staging/addon-resizer:1.8.7-gke.0",
+                    "eu.gcr.io/gke-release-staging/addon-resizer:1.8.7-gke.0"
+                ],
+                "sizeBytes": 50754800
+            },
+            {
+                "names": [
+                    "k8s.gcr.io/ip-masq-agent-amd64@sha256:eb43b4cdc43a50260b82fdd63208e0b2d401ec830b486d0c7a570a6d73854451",
+                    "k8s.gcr.io/ip-masq-agent-amd64:v2.4.1"
+                ],
+                "sizeBytes": 50144412
+            },
+            {
+                "names": [
+                    "k8s.gcr.io/event-exporter@sha256:06acf489ab092b4fb49273e426549a52c0fcd1dbcb67e03d5935b5ee1a899c3e",
+                    "k8s.gcr.io/event-exporter:v0.2.5"
+                ],
+                "sizeBytes": 47261019
+            },
+            {
+                "names": [
+                    "k8s.gcr.io/coredns@sha256:12eb885b8685b1b13a04ecf5c23bc809c2e57917252fd7b0be9e9c00644e8ee5",
+                    "k8s.gcr.io/coredns:1.6.2"
+                ],
+                "sizeBytes": 44100963
+            },
+            {
+                "names": [
+                    "asia.gcr.io/gke-release-staging/cpvpa-amd64@sha256:f2559b448a534713470f4f81045dea65a83a52904fb3dcb3a423ba2723d3783e",
+                    "eu.gcr.io/gke-release-staging/cpvpa-amd64@sha256:f2559b448a534713470f4f81045dea65a83a52904fb3dcb3a423ba2723d3783e"
+                ],
+                "sizeBytes": 44092063
+            },
+            {
+                "names": [
+                    "asia.gcr.io/gke-release-staging/cluster-proportional-autoscaler-amd64@sha256:e3f48b3d1e49cfa3e7f002020769c9cd01cd0e77bbc99dc133c7ab0f8097e989",
+                    "eu.gcr.io/gke-release-staging/cluster-proportional-autoscaler-amd64@sha256:e3f48b3d1e49cfa3e7f002020769c9cd01cd0e77bbc99dc133c7ab0f8097e989",
+                    "gcr.io/gke-release-staging/cluster-proportional-autoscaler-amd64@sha256:e3f48b3d1e49cfa3e7f002020769c9cd01cd0e77bbc99dc133c7ab0f8097e989",
+                    "asia.gcr.io/gke-release-staging/cluster-proportional-autoscaler-amd64:1.7.1-gke.0",
+                    "eu.gcr.io/gke-release-staging/cluster-proportional-autoscaler-amd64:1.7.1-gke.0"
+                ],
+                "sizeBytes": 43947291
+            },
+            {
+                "names": [
+                    "k8s.gcr.io/k8s-dns-sidecar@sha256:c4f36a12fa297c48cb80779c89f6a58818d1fa7edccb08bc67d79acacc3871d7",
+                    "k8s.gcr.io/k8s-dns-sidecar:1.14.13"
+                ],
+                "sizeBytes": 42852039
+            }
+        ]
+    }
+}

--- a/platform/kubernetes/metric_test.go
+++ b/platform/kubernetes/metric_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/mackerelio/mackerel-container-agent/metric"
 	"github.com/mackerelio/mackerel-container-agent/platform/kubernetes/kubelet"
+	"github.com/mackerelio/mackerel-container-agent/platform/kubernetes/kubernetesapi"
 )
 
 func TestGenerateStats(t *testing.T) {
@@ -63,8 +64,9 @@ func TestGenerateStats(t *testing.T) {
 			return &info, nil
 		}),
 	)
-	generator := newMetricGenerator(client, nil) // XXX
-	_, err := generator.Generate(ctx)            // Store metrics to generator.prevStats.
+	serviceClient := kubernetesapi.NewMockClient()
+	generator := newMetricGenerator(client, serviceClient)
+	_, err := generator.Generate(ctx) // Store metrics to generator.prevStats.
 	if err != nil {
 		t.Errorf("Generate() should not raise error: %v", err)
 	}

--- a/platform/kubernetes/metric_test.go
+++ b/platform/kubernetes/metric_test.go
@@ -75,8 +75,8 @@ func TestGenerateStats(t *testing.T) {
 		t.Errorf("Generate() should not raise error: %v", err)
 	}
 	expected := metric.Values{
-		"container.cpu.mackerel-container-agent.usage":    0.0, // Rsult is 0 because use the same data.
-		"container.cpu.nginx.usage":                       0.0, // Rsult is 0 because use the same data.
+		"container.cpu.mackerel-container-agent.usage":    0.0, // Result is 0 because use the same data.
+		"container.cpu.nginx.usage":                       0.0, // Result is 0 because use the same data.
 		"container.cpu.mackerel-container-agent.limit":    25.0,
 		"container.cpu.nginx.limit":                       200.0,
 		"container.memory.mackerel-container-agent.usage": 2.6529792e+07,

--- a/platform/kubernetes/metric_test.go
+++ b/platform/kubernetes/metric_test.go
@@ -63,8 +63,8 @@ func TestGenerateStats(t *testing.T) {
 			return &info, nil
 		}),
 	)
-	generator := newMetricGenerator(client)
-	_, err := generator.Generate(ctx) // Store metrics to generator.prevStats.
+	generator := newMetricGenerator(client, nil) // XXX
+	_, err := generator.Generate(ctx)            // Store metrics to generator.prevStats.
 	if err != nil {
 		t.Errorf("Generate() should not raise error: %v", err)
 	}

--- a/platform/kubernetes/metric_test.go
+++ b/platform/kubernetes/metric_test.go
@@ -89,6 +89,81 @@ func TestGenerateStats(t *testing.T) {
 	}
 }
 
+func TestGenerateStats_FallbackToNodeAPI(t *testing.T) {
+	ctx := context.Background()
+	client := kubelet.NewMockClient(
+		kubelet.MockGetPod(func(context.Context) (*kubernetesTypes.Pod, error) {
+			raw, err := ioutil.ReadFile("kubelet/testdata/pods.json")
+			if err != nil {
+				return nil, err
+			}
+			var podList kubernetesTypes.PodList
+			if err := json.Unmarshal(raw, &podList); err != nil {
+				return nil, err
+			}
+			for _, pod := range podList.Items {
+				if pod.ObjectMeta.Namespace == "default" && pod.ObjectMeta.Name == "myapp" {
+					return &pod, nil
+				}
+			}
+			return nil, nil
+		}),
+		kubelet.MockGetPodStats(func(context.Context) (*kubeletTypes.PodStats, error) {
+			raw, err := ioutil.ReadFile("kubelet/testdata/summary.json")
+			if err != nil {
+				return nil, err
+			}
+			var summary kubeletTypes.Summary
+			if err := json.Unmarshal(raw, &summary); err != nil {
+				return nil, err
+			}
+			for _, pod := range summary.Pods {
+				if pod.PodRef.Namespace == "default" && pod.PodRef.Name == "myapp" {
+					return &pod, nil
+				}
+			}
+			return nil, nil
+		}),
+		kubelet.MockGetSpec(func(context.Context) (*cadvisorTypes.MachineInfo, error) {
+			return nil, kubelet.ErrNotFound
+		}),
+	)
+	serviceClient := kubernetesapi.NewMockClient(
+		kubernetesapi.MockGetNode(func(context.Context) (*kubernetesTypes.Node, error) {
+			raw, err := ioutil.ReadFile("kubernetesapi/testdata/node.json")
+			if err != nil {
+				return nil, err
+			}
+			var info kubernetesTypes.Node
+			if err := json.Unmarshal(raw, &info); err != nil {
+				return nil, err
+			}
+			return &info, nil
+		}),
+	)
+	generator := newMetricGenerator(client, serviceClient)
+	_, err := generator.Generate(ctx) // Store metrics to generator.prevStats.
+	if err != nil {
+		t.Errorf("Generate() should not raise error: %v", err)
+	}
+	got, err := generator.Generate(ctx)
+	if err != nil {
+		t.Errorf("Generate() should not raise error: %v", err)
+	}
+	expected := metric.Values{
+		"container.cpu.mackerel-container-agent.usage":    0.0, // Result is 0 because use the same data.
+		"container.cpu.nginx.usage":                       0.0, // Result is 0 because use the same data.
+		"container.cpu.mackerel-container-agent.limit":    25.0,
+		"container.cpu.nginx.limit":                       100.0, // taken from Node API
+		"container.memory.mackerel-container-agent.usage": 2.6529792e+07,
+		"container.memory.nginx.usage":                    1.949696e+06,
+		"container.memory.mackerel-container-agent.limit": 134217728.0,  // 128MiB
+		"container.memory.nginx.limit":                    3876802560.0, // taken from Node API
+	}
+	if !reflect.DeepEqual(expected, got) {
+		t.Errorf("Generate() expected %v, got %v", expected, got)
+	}
+}
 func TestGetMemoryLimit(t *testing.T) {
 	hostMemTotal := 2096058368.0
 	name := "dummy"


### PR DESCRIPTION
#78 

# how it works

Default behavior is kept same. At first we still access Kubelet `/spec` to retrieve node information.  Therefore, On Kubernetes < 1.18, everything kept same. (In future maybe we'll change this behavior to simplify, but this breaks backward compatibility for Kubernetes < 1.18 users)

On Kubernetes >= 1.18, agent will get 404 on accessing Kubelet `/spec`, then it will access Kubernetes `/v1/api/nodes/${node_name}` instead.  The endpoint also provides node information, so use the information instead.

# Required configuration change for Kubernetes 1.18+

To access Kubernetes API, some configurations will change in Kubernetes 1.18+.
- will need `MACKEREL_KUBERNETES_NODE_NAME` env
  - always necessary on EKS on Fargate (ref: https://mackerel.io/docs/entry/howto/install-agent/container/eks-on-fargate)
- will need additional Cluster Role privileges: `get` on `nodes`
  - example: https://github.com/astj/sandbox-container-agent/blob/main/rbac.yml#L8
- will require Service Account Token mounted, even if Kubelet read_only port is used
  - if you're NOT using read_only_port, it's already mandatory
