### PR TITLE
Release version 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.5.0 (2020-10-27)
+
+* [Kubernetes] Retrieve node CPU/memory capacity from local information, not from kubelet /spec #80 (astj)
+* add dependent: gobump #74 (lufia)
+
+
 ## 0.4.0 (2020-07-16)
 
 * disable HTTP/2 #73 (lufia)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 BIN := mackerel-container-agent
-VERSION := 0.4.0
+VERSION := 0.5.0
 REVISION := $(shell git rev-parse --short HEAD)
 
 export GO111MODULE=on


### PR DESCRIPTION
- [Kubernetes] Retrieve node CPU/memory capacity from local information, not from kubelet /spec #80
- add dependent: gobump #74
