### PR TITLE
improve S3 config loader error messages

### DIFF
--- a/config/s3.go
+++ b/config/s3.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -23,7 +24,7 @@ func (d s3Downloader) download(ctx context.Context, u *url.URL) ([]byte, error) 
 
 	r, err := s3manager.GetBucketRegion(ctx, sess, u.Host, d.regionHint)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get bucket region for %s: %w", u.Host, err)
 	}
 	sess.Config.Region = aws.String(r)
 
@@ -35,7 +36,7 @@ func (d s3Downloader) download(ctx context.Context, u *url.URL) ([]byte, error) 
 		Key:    aws.String(u.Path),
 	})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to download config from %s: %w", u, err)
 	}
 
 	return buf.Bytes(), nil

--- a/config/s3.go
+++ b/config/s3.go
@@ -30,7 +30,7 @@ func (d s3Downloader) download(ctx context.Context, u *url.URL) ([]byte, error) 
 	downloader := s3manager.NewDownloader(sess)
 
 	buf := &aws.WriteAtBuffer{}
-	_, err = downloader.Download(buf, &s3.GetObjectInput{
+	_, err = downloader.DownloadWithContext(ctx, buf, &s3.GetObjectInput{
 		Bucket: aws.String(u.Host),
 		Key:    aws.String(u.Path),
 	})


### PR DESCRIPTION
When the S3 config loader fails to download the config, we get log message like 
```
ERROR <main> AccessDenied: Access Denied
ERROR <main> NoSuchKey: The specified key does not exist.
```
It is difficult to tell these messages comes from the S3 downloader. I think it's worth improving the error messages.