### PR TITLE
[nit] use %w verb to wrap errors

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -83,7 +83,7 @@ func createConfLoader() (*config.Loader, error) {
 	); durationMinutesStr != "" {
 		durationMinutes, err := strconv.Atoi(durationMinutesStr)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse config polling duration: %s", err)
+			return nil, fmt.Errorf("failed to parse config polling duration: %w", err)
 		}
 		pollingDuration = time.Duration(durationMinutes) * time.Minute
 	}

--- a/agent/host_resolver.go
+++ b/agent/host_resolver.go
@@ -7,8 +7,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	mackerel "github.com/mackerelio/mackerel-client-go"
 
 	"github.com/mackerelio/mackerel-container-agent/api"
@@ -44,13 +42,13 @@ func (r *hostResolver) getHost(hostParam *mackerel.CreateHostParam) (*mackerel.H
 					},
 				})
 				if err != nil {
-					return nil, retryFromError(err), errors.Wrap(err, "failed to find host for custom identifier = "+hostParam.CustomIdentifier)
+					return nil, retryFromError(err), fmt.Errorf("failed to find host for custom identifier = %s: %w", hostParam.CustomIdentifier, err)
 				}
 				if len(hosts) > 0 {
 					host = hosts[0]
 					_, err = r.client.UpdateHost(host.ID, (*mackerel.UpdateHostParam)(hostParam))
 					if err != nil {
-						return nil, retryFromError(err), errors.Wrap(err, "failed to update host for id = "+host.ID)
+						return nil, retryFromError(err), fmt.Errorf("failed to update host for id = %s: %w", host.ID, err)
 					}
 					return host, false, r.saveHostID(host.ID)
 				}
@@ -58,14 +56,14 @@ func (r *hostResolver) getHost(hostParam *mackerel.CreateHostParam) (*mackerel.H
 			// create a new host
 			hostID, err := r.client.CreateHost(hostParam)
 			if err != nil {
-				return nil, retryFromError(err), errors.Wrap(err, "failed to create a new host")
+				return nil, retryFromError(err), fmt.Errorf("failed to create a new host: %w", err)
 			}
 			if err := r.saveHostID(hostID); err != nil {
 				return nil, false, err
 			}
 			host, err = r.client.FindHost(hostID)
 			if err != nil {
-				return nil, retryFromError(err), errors.Wrap(err, "failed to find host for id = "+hostID)
+				return nil, retryFromError(err), fmt.Errorf("failed to find host for id = %s: %w", hostID, err)
 			}
 			return host, false, nil
 		}
@@ -77,11 +75,11 @@ func (r *hostResolver) getHost(hostParam *mackerel.CreateHostParam) (*mackerel.H
 	}
 	host, err = r.client.FindHost(hostID)
 	if err != nil {
-		return nil, retryFromError(err), errors.Wrap(err, "failed to find host for id = "+hostID)
+		return nil, retryFromError(err), fmt.Errorf("failed to find host for id = %s: %w", hostID, err)
 	}
 	_, err = r.client.UpdateHost(host.ID, (*mackerel.UpdateHostParam)(hostParam))
 	if err != nil {
-		return nil, retryFromError(err), errors.Wrap(err, "failed to update host for id = "+hostID)
+		return nil, retryFromError(err), fmt.Errorf("failed to update host for id = %s: %w", hostID, err)
 	}
 	return host, false, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mackerelio/mackerel-container-agent
 
-go 1.12
+go 1.15
 
 require (
 	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 // indirect

--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,6 @@ require (
 	github.com/opencontainers/image-spec v1.0.1 // indirect
 	github.com/opencontainers/runtime-spec v0.1.2-0.20190408193819-a1b50f621a48 // indirect
 	github.com/pborman/uuid v1.2.0 // indirect
-	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829 // indirect
 	github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90 // indirect
 	github.com/prometheus/common v0.3.0 // indirect

--- a/metric/plugin.go
+++ b/metric/plugin.go
@@ -37,7 +37,7 @@ func (g *pluginGenerator) Generate(ctx context.Context) (Values, error) {
 		logger.Infof("plugin %s (%s): %q", g.Name, g.Command, stderr)
 	}
 	if err != nil {
-		return nil, fmt.Errorf("plugin %s (%s): %s", g.Name, g.Command, err)
+		return nil, fmt.Errorf("plugin %s (%s): %w", g.Name, g.Command, err)
 	}
 
 	values := make(Values)
@@ -79,7 +79,7 @@ func (g *pluginGenerator) GetGraphDefs(ctx context.Context) ([]*mackerel.GraphDe
 		logger.Infof("plugin %s (%s): %q", g.Name, g.Command, stderr)
 	}
 	if err != nil {
-		return nil, fmt.Errorf("plugin %s (%s): %s", g.Name, g.Command, err)
+		return nil, fmt.Errorf("plugin %s (%s): %w", g.Name, g.Command, err)
 	}
 
 	xs := strings.SplitN(stdout, "\n", 2)
@@ -90,7 +90,7 @@ func (g *pluginGenerator) GetGraphDefs(ctx context.Context) ([]*mackerel.GraphDe
 
 	var conf pluginMeta
 	if err = json.Unmarshal([]byte(xs[1]), &conf); err != nil {
-		return nil, fmt.Errorf("plugin %s: failed to decode plugin meta: %s", g.Name, err)
+		return nil, fmt.Errorf("plugin %s: failed to decode plugin meta: %w", g.Name, err)
 	}
 
 	var graphDefs []*mackerel.GraphDefsParam

--- a/probe/http.go
+++ b/probe/http.go
@@ -66,7 +66,7 @@ func (p *probeHTTP) Check(ctx context.Context) error {
 
 	res, err := client.Do(req.WithContext(ctx))
 	if err != nil {
-		return fmt.Errorf("http probe failed (%s %s): %s", method, u, err)
+		return fmt.Errorf("http probe failed (%s %s): %w", method, u, err)
 	}
 	defer res.Body.Close()
 

--- a/probe/tcp.go
+++ b/probe/tcp.go
@@ -30,7 +30,7 @@ func (p *probeTCP) Check(ctx context.Context) error {
 	d := net.Dialer{Timeout: timeout}
 	conn, err := d.DialContext(ctx, "tcp", addr)
 	if err != nil {
-		return fmt.Errorf("tcp probe failed (%s): %s", addr, err)
+		return fmt.Errorf("tcp probe failed (%s): %w", addr, err)
 	}
 	defer conn.Close()
 


### PR DESCRIPTION
Since Go 1.13, it is recommended to use `%w` to wrap the errors, instead of using `%s` or `pkg/errors`.

Ref: https://blog.golang.org/go1.13-errors