### PR TITLE
[nit] Change arg name for NewEKSOnFargatePlatform

### DIFF
--- a/platform/kubernetes/kubernetes.go
+++ b/platform/kubernetes/kubernetes.go
@@ -76,13 +76,13 @@ func NewKubernetesPlatform(kubeletHost, kubeletPort string, useReadOnlyPort, ins
 }
 
 // NewEKSOnFargatePlatform creates a new Platform
-func NewEKSOnFargatePlatform(kubeletHost, kubeletPort string, namespace, podName string, nodeName string, ignoreContainer *regexp.Regexp) (platform.Platform, error) {
+func NewEKSOnFargatePlatform(kubernetesHost, kubernetesPort string, namespace, podName string, nodeName string, ignoreContainer *regexp.Regexp) (platform.Platform, error) {
 	var caCert, token []byte
 	var err error
 
 	baseURL := &url.URL{
 		Scheme: "https",
-		Host:   net.JoinHostPort(kubeletHost, kubeletPort),
+		Host:   net.JoinHostPort(kubernetesHost, kubernetesPort),
 		Path:   path.Join("api", "v1", "nodes", nodeName, "proxy"),
 	}
 

--- a/platform/kubernetes/kubernetes.go
+++ b/platform/kubernetes/kubernetes.go
@@ -76,7 +76,7 @@ func NewKubernetesPlatform(kubeletHost, kubeletPort string, useReadOnlyPort, ins
 }
 
 // NewEKSOnFargatePlatform creates a new Platform
-// on this playform, agent accesses Kubelet via Kubernetes API (/api/v1/nodes/{nodeName}/proxy)
+// on this platform, agent accesses Kubelet via Kubernetes API (/api/v1/nodes/{nodeName}/proxy)
 func NewEKSOnFargatePlatform(kubernetesHost, kubernetesPort string, namespace, podName string, nodeName string, ignoreContainer *regexp.Regexp) (platform.Platform, error) {
 	var caCert, token []byte
 	var err error

--- a/platform/kubernetes/kubernetes.go
+++ b/platform/kubernetes/kubernetes.go
@@ -76,6 +76,7 @@ func NewKubernetesPlatform(kubeletHost, kubeletPort string, useReadOnlyPort, ins
 }
 
 // NewEKSOnFargatePlatform creates a new Platform
+// on this playform, agent accesses Kubelet via Kubernetes API (/api/v1/nodes/{nodeName}/proxy)
 func NewEKSOnFargatePlatform(kubernetesHost, kubernetesPort string, namespace, podName string, nodeName string, ignoreContainer *regexp.Regexp) (platform.Platform, error) {
 	var caCert, token []byte
 	var err error


### PR DESCRIPTION
Currently `NewEKSOnFargatePlatform`'s first two args are named `kubelet{Host,Port}`, but actually they are not host/port for Kubelet but for Kubernetes API.

So I'd like to change their name to avoid confusion.