### PR TITLE
probe, spec: reduce the flakiness of tests

### DIFF
--- a/metric/manager_test.go
+++ b/metric/manager_test.go
@@ -27,8 +27,14 @@ func TestManagerRun(t *testing.T) {
 		t.Errorf("err should be nil but got: %+v", err)
 	}
 	metricValues := client.PostedMetricValues()
-	if expected := 9 * 4; len(metricValues[hostID]) != expected {
-		t.Errorf("metric values should have size %d but got: %#v", expected, metricValues[hostID])
+
+	const (
+		metricNum   = 9
+		expected    = 4 * metricNum
+		expectedMin = 1 * metricNum
+	)
+	if n := len(metricValues[hostID]); n < expectedMin || n > expected {
+		t.Errorf("metric values should have size %d but got: %d", expected, n)
 	}
 	graphDefs := client.PostedGraphDefs()
 	if expected := 2; len(graphDefs) != expected {

--- a/metric/manager_test.go
+++ b/metric/manager_test.go
@@ -28,6 +28,7 @@ func TestManagerRun(t *testing.T) {
 	}
 	metricValues := client.PostedMetricValues()
 
+	// This test is flaky so we should check the count with an accuracy.
 	const (
 		metricNum   = 9
 		expected    = 4 * metricNum

--- a/probe/probe_test.go
+++ b/probe/probe_test.go
@@ -53,6 +53,7 @@ func TestProbe_Wait(t *testing.T) {
 		initialDelay time.Duration
 		period       time.Duration
 		count        int
+		accuracy     int
 		duration     time.Duration
 	}{
 		{
@@ -71,6 +72,7 @@ func TestProbe_Wait(t *testing.T) {
 			name:     "stop by duration",
 			results:  []bool{false},
 			count:    3,
+			accuracy: 1,
 			duration: 250 * time.Millisecond,
 		},
 		{
@@ -78,6 +80,7 @@ func TestProbe_Wait(t *testing.T) {
 			results:  []bool{false},
 			period:   50 * time.Millisecond,
 			count:    4,
+			accuracy: 1,
 			duration: 170 * time.Millisecond,
 		},
 		{
@@ -85,6 +88,7 @@ func TestProbe_Wait(t *testing.T) {
 			results:      []bool{false},
 			initialDelay: 200 * time.Millisecond,
 			count:        2,
+			accuracy:     1,
 			duration:     350 * time.Millisecond,
 		},
 	}
@@ -95,9 +99,18 @@ func TestProbe_Wait(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), tc.duration)
 			defer cancel()
 			Wait(ctx, p)
-			if p.count != tc.count {
-				t.Errorf("Wait should check %v times but but got %v", tc.count, p.count)
-			}
+			testWaitAccuracy(t, p.count, tc.count, tc.accuracy)
 		})
+	}
+}
+
+func testWaitAccuracy(t testing.TB, count, want, accuracy int) {
+	t.Helper()
+	switch {
+	case count == want:
+	case count == want+accuracy:
+	case count == want-accuracy:
+	default:
+		t.Errorf("Wait should check %d times with accuracy %d but got %d", want, accuracy, count)
 	}
 }

--- a/probe/probe_test.go
+++ b/probe/probe_test.go
@@ -99,18 +99,11 @@ func TestProbe_Wait(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), tc.duration)
 			defer cancel()
 			Wait(ctx, p)
-			testWaitAccuracy(t, p.count, tc.count, tc.accuracy)
-		})
-	}
-}
 
-func testWaitAccuracy(t testing.TB, count, want, accuracy int) {
-	t.Helper()
-	switch {
-	case count == want:
-	case count == want+accuracy:
-	case count == want-accuracy:
-	default:
-		t.Errorf("Wait should check %d times with accuracy %d but got %d", want, accuracy, count)
+			// This test is flaky so we should check the count with an accuracy.
+			if p.count < tc.count-tc.accuracy || p.count > tc.count+tc.accuracy {
+				t.Errorf("Wait should check %d times with accuracy %d but got %d", tc.count, tc.accuracy, p.count)
+			}
+		})
 	}
 }

--- a/spec/manager_test.go
+++ b/spec/manager_test.go
@@ -46,7 +46,14 @@ func TestManagerRun(t *testing.T) {
 	if err != nil {
 		t.Errorf("err should be nil but got: %+v", err)
 	}
-	testRunAccuracy(t, updatedCount, 5, 1)
+	// This test is flaky so we should check the count with an accuracy.
+	const (
+		expected = 5
+		accuracy = 1
+	)
+	if updatedCount < expected-accuracy || updatedCount > expected+accuracy {
+		t.Errorf("update host api is called %d times (expected: %d times with accuracy %d)", updatedCount, expected, accuracy)
+	}
 }
 
 func TestManagerRun_LazyHostID(t *testing.T) {
@@ -82,17 +89,13 @@ func TestManagerRun_LazyHostID(t *testing.T) {
 	if err != nil {
 		t.Errorf("err should be nil but got: %+v", err)
 	}
-	testRunAccuracy(t, updatedCount, 3, 1)
-}
-
-func testRunAccuracy(t testing.TB, count, want, accuracy int) {
-	t.Helper()
-	switch {
-	case count == want:
-	case count == want+accuracy:
-	case count == want-accuracy:
-	default:
-		t.Errorf("update host api is called %d times (expected: %d times with accuracy %d)", count, want, accuracy)
+	// This test is flaky so we should check the count with an accuracy.
+	const (
+		expected = 3
+		accuracy = 1
+	)
+	if updatedCount < expected-accuracy || updatedCount > expected+accuracy {
+		t.Errorf("update host api is called %d times (expected: %d times with accuracy %d)", updatedCount, expected, accuracy)
 	}
 }
 

--- a/spec/manager_test.go
+++ b/spec/manager_test.go
@@ -46,9 +46,7 @@ func TestManagerRun(t *testing.T) {
 	if err != nil {
 		t.Errorf("err should be nil but got: %+v", err)
 	}
-	if expected := 5; updatedCount != expected {
-		t.Errorf("update host api is called %d times (expected: %d times)", updatedCount, expected)
-	}
+	testRunAccuracy(t, updatedCount, 5, 1)
 }
 
 func TestManagerRun_LazyHostID(t *testing.T) {
@@ -84,8 +82,17 @@ func TestManagerRun_LazyHostID(t *testing.T) {
 	if err != nil {
 		t.Errorf("err should be nil but got: %+v", err)
 	}
-	if expected := 3; updatedCount != expected {
-		t.Errorf("update host api is called %d times (expected: %d times)", updatedCount, expected)
+	testRunAccuracy(t, updatedCount, 3, 1)
+}
+
+func testRunAccuracy(t testing.TB, count, want, accuracy int) {
+	t.Helper()
+	switch {
+	case count == want:
+	case count == want+accuracy:
+	case count == want-accuracy:
+	default:
+		t.Errorf("update host api is called %d times (expected: %d times with accuracy %d)", count, want, accuracy)
 	}
 }
 


### PR DESCRIPTION
Some tests are flaky. These tests don't be needed that trials count are same as expected count perfectly. Goroutines might be delayed woken up by Go runtime.