### PR TITLE
Use multi-stage builds

### DIFF
--- a/Dockerfile.multistage
+++ b/Dockerfile.multistage
@@ -1,4 +1,4 @@
-FROM golang:1.17-stretch
+FROM golang:1.17-stretch AS builder
 
 WORKDIR /go/src/app
 
@@ -18,7 +18,7 @@ RUN apt-get update -yq && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists
 
-COPY --from=0 /go/src/app/build/mackerel-container-agent /usr/local/bin/
+COPY --from=builder /go/src/app/build/mackerel-container-agent /usr/local/bin/
 
 ENTRYPOINT ["/usr/local/bin/mackerel-container-agent"]
 

--- a/Dockerfile.multistage
+++ b/Dockerfile.multistage
@@ -8,3 +8,17 @@ RUN go mod download
 COPY . .
 RUN make build
 
+FROM debian:stretch-slim AS container-agent
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV GODEBUG http2client=0
+
+RUN apt-get update -yq && \
+    apt-get install -yq --no-install-recommends ca-certificates sudo && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists
+
+COPY --from=0 /go/src/app/build/mackerel-container-agent /usr/local/bin/
+
+ENTRYPOINT ["/usr/local/bin/mackerel-container-agent"]
+

--- a/Dockerfile.multistage
+++ b/Dockerfile.multistage
@@ -1,0 +1,10 @@
+FROM golang:1.17-stretch
+
+WORKDIR /go/src/app
+
+COPY go.sum go.mod ./
+RUN go mod download
+
+COPY . .
+RUN make build
+

--- a/Dockerfile.multistage
+++ b/Dockerfile.multistage
@@ -22,3 +22,25 @@ COPY --from=0 /go/src/app/build/mackerel-container-agent /usr/local/bin/
 
 ENTRYPOINT ["/usr/local/bin/mackerel-container-agent"]
 
+FROM container-agent AS container-agent-with-plugins
+
+ENV BUNDLE_AGENT_PLUGINS apache2|elasticsearch|fluentd|gostats|haproxy|jmx-jolokia|memcached|mysql|nginx|php-apc|php-fpm|php-opcache|plack|postgres|redis|sidekiq|snmp|squid|uwsgi-vassal
+ENV BUNDLE_CHECK_PLUGINS cert-file|elasticsearch|file-age|file-size|http|jmx-jolokia|log|memcached|mysql|postgresql|redis|ssh|ssl-cert|tcp
+ENV MKR_INSTALL_PLUGINS json
+
+RUN apt-get update -yq && \
+    apt-get install -yq --no-install-recommends curl gnupg2
+RUN echo "deb [arch=amd64] http://apt.mackerel.io/v2/ mackerel contrib" > /etc/apt/sources.list.d/mackerel.list
+RUN curl -LfsS https://mackerel.io/file/cert/GPG-KEY-mackerel-v2 | apt-key add -
+
+RUN apt-get update -yq && \
+    apt-get install -yq --no-install-recommends mackerel-agent-plugins mackerel-check-plugins mkr && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists
+
+RUN find /usr/bin/ -type l -regextype posix-egrep -name 'mackerel-plugin-*' -a ! -regex ".*mackerel-plugin-(${BUNDLE_AGENT_PLUGINS})" -delete
+RUN find /usr/bin/ -type l -regextype posix-egrep -name 'check-*' -a ! -regex ".*check-(${BUNDLE_CHECK_PLUGINS})" -delete
+
+RUN echo ${MKR_INSTALL_PLUGINS} | tr ' ' '\n' | xargs -I@ mkr plugin install mackerel-plugin-@
+ENV PATH $PATH:/opt/mackerel-agent/plugins/bin
+

--- a/Dockerfile.multistage
+++ b/Dockerfile.multistage
@@ -15,7 +15,6 @@ ENV GODEBUG http2client=0
 
 RUN apt-get update -yq && \
     apt-get install -yq --no-install-recommends ca-certificates sudo && \
-    apt-get clean && \
     rm -rf /var/lib/apt/lists
 
 COPY --from=builder /go/src/app/build/mackerel-container-agent /usr/local/bin/
@@ -35,7 +34,6 @@ RUN curl -LfsS https://mackerel.io/file/cert/GPG-KEY-mackerel-v2 | apt-key add -
 
 RUN apt-get update -yq && \
     apt-get install -yq --no-install-recommends mackerel-agent-plugins mackerel-check-plugins mkr && \
-    apt-get clean && \
     rm -rf /var/lib/apt/lists
 
 RUN find /usr/bin/ -type l -regextype posix-egrep -name 'mackerel-plugin-*' -a ! -regex ".*mackerel-plugin-(${BUNDLE_AGENT_PLUGINS})" -delete

--- a/Dockerfile.multistage
+++ b/Dockerfile.multistage
@@ -30,7 +30,7 @@ ENV MKR_INSTALL_PLUGINS json
 
 RUN apt-get update -yq && \
     apt-get install -yq --no-install-recommends curl gnupg2
-RUN echo "deb [arch=amd64] http://apt.mackerel.io/v2/ mackerel contrib" > /etc/apt/sources.list.d/mackerel.list
+RUN echo "deb [arch=amd64,arm64] http://apt.mackerel.io/v2/ mackerel contrib" > /etc/apt/sources.list.d/mackerel.list
 RUN curl -LfsS https://mackerel.io/file/cert/GPG-KEY-mackerel-v2 | apt-key add -
 
 RUN apt-get update -yq && \


### PR DESCRIPTION
It is separated into two files(`Dockerfile` `Dockerfile.plugins`), which hinders updating the build procedure, so integrate the contents of the files.
Also, instead of adding the generated binary separately, generate it in the procedure.

I haven't updated the CI procedure, so add it as a file with a different name.