### PR TITLE
[bug-fix] add ContainerHealthStatus json marshal/unmarshal methods

### DIFF
--- a/internal/amazon-ecs-agent/agent/api/container/status/containerstatus.go
+++ b/internal/amazon-ecs-agent/agent/api/container/status/containerstatus.go
@@ -13,5 +13,69 @@
 
 package status
 
+import (
+	"errors"
+	"strings"
+)
+
+const (
+	// ContainerHealthUnknown is the initial status of container health
+	ContainerHealthUnknown ContainerHealthStatus = iota
+	// ContainerHealthy represents the status of container health check when returned healthy
+	ContainerHealthy
+	// ContainerUnhealthy represents the status of container health check when returned unhealthy
+	ContainerUnhealthy
+)
+
 // ContainerHealthStatus is an enumeration of container health check status
 type ContainerHealthStatus int32
+
+// BackendStatus returns the container health status recognized by backend
+func (healthStatus ContainerHealthStatus) BackendStatus() string {
+	switch healthStatus {
+	case ContainerHealthy:
+		return "HEALTHY"
+	case ContainerUnhealthy:
+		return "UNHEALTHY"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// String returns the readable description of the container health status
+func (healthStatus ContainerHealthStatus) String() string {
+	return healthStatus.BackendStatus()
+}
+
+// UnmarshalJSON overrides the logic for parsing the JSON-encoded container health data
+func (healthStatus *ContainerHealthStatus) UnmarshalJSON(b []byte) error {
+	*healthStatus = ContainerHealthUnknown
+
+	if strings.ToLower(string(b)) == "null" {
+		return nil
+	}
+	if b[0] != '"' || b[len(b)-1] != '"' {
+		return errors.New("container health status unmarshal: status must be a string or null; Got " + string(b))
+	}
+
+	strStatus := string(b[1 : len(b)-1])
+	switch strStatus {
+	case "UNKNOWN":
+	// The health status is already set to ContainerHealthUnknown initially
+	case "HEALTHY":
+		*healthStatus = ContainerHealthy
+	case "UNHEALTHY":
+		*healthStatus = ContainerUnhealthy
+	default:
+		return errors.New("container health status unmarshal: unrecognized status: " + string(b))
+	}
+	return nil
+}
+
+// MarshalJSON overrides the logic for JSON-encoding the ContainerHealthStatus type
+func (healthStatus *ContainerHealthStatus) MarshalJSON() ([]byte, error) {
+	if healthStatus == nil {
+		return nil, nil
+	}
+	return []byte(`"` + healthStatus.String() + `"`), nil
+}


### PR DESCRIPTION
Because marshal/unmarshal methods are not implemented for `ContainerHealthStatus`, now mackerel-container-agent seems to always fail on AWS ECS if health check enabled. So I added marshal/unmarshal methods.