### PR TITLE
add support Amazon ECS Anywhere ( experimental )

### DIFF
--- a/agent/platform.go
+++ b/agent/platform.go
@@ -35,6 +35,16 @@ func NewPlatform(ctx context.Context, ignoreContainer *regexp.Regexp) (platform.
 		}
 		return ecs.NewECSPlatform(ctx, metadataURI, executionEnv, ignoreContainer)
 
+	// experimental : on AWS ECS External Instance, `AWS_EXECUTION_ENV` is not defined.
+	// follow user's `MACKEREL_CONTAINER_PLATFORM` setting and using unique value that does not interfere with AWS.
+	case platform.ECSExternal:
+		metadataURI, err := getEnvValue("ECS_CONTAINER_METADATA_URI")
+		if err != nil {
+			return nil, err
+		}
+		executionEnv := "ECS_EXTERNAL"
+		return ecs.NewECSPlatform(ctx, metadataURI, executionEnv, ignoreContainer)
+
 	case platform.Kubernetes:
 		useReadOnlyPort := true
 		insecureTLS := false

--- a/agent/platform.go
+++ b/agent/platform.go
@@ -42,7 +42,7 @@ func NewPlatform(ctx context.Context, ignoreContainer *regexp.Regexp) (platform.
 		if err != nil {
 			return nil, err
 		}
-		executionEnv := "ECS_EXTERNAL"
+		executionEnv := ecs.ExecutionEnvExternal
 		return ecs.NewECSPlatform(ctx, metadataURI, executionEnv, ignoreContainer)
 
 	case platform.Kubernetes:

--- a/platform/ecs/ecs.go
+++ b/platform/ecs/ecs.go
@@ -126,6 +126,8 @@ func resolveProvider(executionEnv string) (provider, error) {
 		return fargateProvider, nil
 	case executionEnvEC2:
 		return ecsProvider, nil
+	case executionEnvExternal:
+		return externalProvider, nil
 	default:
 		return provider("UNKNOWN"), fmt.Errorf("unknown execution env: %q", executionEnv)
 	}

--- a/platform/ecs/ecs.go
+++ b/platform/ecs/ecs.go
@@ -21,6 +21,9 @@ import (
 const (
 	executionEnvFargate = "AWS_ECS_FARGATE"
 	executionEnvEC2     = "AWS_ECS_EC2"
+	// experimental : on AWS ECS External Instance, `AWS_EXECUTION_ENV` is not defined.
+	// follow user's `MACKEREL_CONTAINER_PLATFORM` setting and using unique value that does not interfere with AWS.
+	executionEnvExternal = "ECS_EXTERNAL"
 )
 
 var (

--- a/platform/ecs/ecs.go
+++ b/platform/ecs/ecs.go
@@ -21,9 +21,9 @@ import (
 const (
 	executionEnvFargate = "AWS_ECS_FARGATE"
 	executionEnvEC2     = "AWS_ECS_EC2"
-	// experimental : on AWS ECS External Instance, `AWS_EXECUTION_ENV` is not defined.
-	// follow user's `MACKEREL_CONTAINER_PLATFORM` setting and using unique value that does not interfere with AWS.
-	executionEnvExternal = "ECS_EXTERNAL"
+
+	// ExecutionEnvExternal : (experimental) It is a definition that is handled internally, not an environment variable.
+	ExecutionEnvExternal = "ECS_EXTERNAL"
 )
 
 var (
@@ -126,7 +126,7 @@ func resolveProvider(executionEnv string) (provider, error) {
 		return fargateProvider, nil
 	case executionEnvEC2:
 		return ecsProvider, nil
-	case executionEnvExternal:
+	case ExecutionEnvExternal:
 		return externalProvider, nil
 	default:
 		return provider("UNKNOWN"), fmt.Errorf("unknown execution env: %q", executionEnv)

--- a/platform/ecs/ecs_test.go
+++ b/platform/ecs/ecs_test.go
@@ -39,6 +39,7 @@ func TestResolveProvider(t *testing.T) {
 	}{
 		{"AWS_ECS_FARGATE", fargateProvider},
 		{"AWS_ECS_EC2", ecsProvider},
+		{"ECS_EXTERNAL", externalProvider},
 		{"unknown", provider("UNKNOWN")},
 		{"", provider("UNKNOWN")},
 	}

--- a/platform/ecs/provider.go
+++ b/platform/ecs/provider.go
@@ -6,4 +6,6 @@ type provider string
 const (
 	ecsProvider     provider = "ecs"
 	fargateProvider provider = "fargate"
+	// experimental
+	externalProvider provider = "external"
 )

--- a/platform/ecs/spec_test.go
+++ b/platform/ecs/spec_test.go
@@ -20,6 +20,7 @@ func TestGenerateSpec(t *testing.T) {
 		{"taskmetadata/testdata/metadata_ec2_host.json", ecsProvider},
 		{"taskmetadata/testdata/metadata_ec2_awsvpc.json", ecsProvider},
 		{"taskmetadata/testdata/metadata_fargate.json", fargateProvider},
+		{"taskmetadata/testdata/metadata_external.json", externalProvider},
 	}
 
 	var path string

--- a/platform/ecs/taskmetadata/testdata/metadata_external.json
+++ b/platform/ecs/taskmetadata/testdata/metadata_external.json
@@ -1,0 +1,49 @@
+{
+    "Cluster": "test-clusrer",
+    "TaskARN": "arn:aws:ecs:ap-northeast-1:999999999999:task/task-id",
+    "Family": "test-external",
+    "Revision": "4",
+    "DesiredStatus": "RUNNING",
+    "KnownStatus": "RUNNING",
+    "Limits": {
+      "CPU": 0.25,
+      "Memory": 256
+    },
+    "PullStartedAt": "2022-03-14T06:44:39.928830311Z",
+    "PullStoppedAt": "2022-03-14T06:44:42.387434211Z",
+    "LaunchType": "EXTERNAL",
+    "Containers": [
+      {
+        "DockerId": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        "Name": "mackerel-container-agent",
+        "DockerName": "ecs-test-cluster-1-mackerel-container-agent-ffffffffffffffffffff",
+        "Image": "mackerel/mackerel-container-agent:latest",
+        "ImageID": "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        "Labels": {
+          "com.amazonaws.ecs.cluster": "test-cluster",
+          "com.amazonaws.ecs.container-name": "mackerel-container-agent",
+          "com.amazonaws.ecs.task-arn": "arn:aws:ecs:ap-northeast-1:999999999999:task/task-id",
+          "com.amazonaws.ecs.task-definition-family": "test-fargate",
+          "com.amazonaws.ecs.task-definition-version": "1"
+        },
+        "DesiredStatus": "RUNNING",
+        "KnownStatus": "RUNNING",
+        "Limits": {
+          "CPU": 0,
+          "Memory": 128
+        },
+        "CreatedAt": "2019-03-29T02:54:57.61447652Z",
+        "StartedAt": "2019-03-29T02:54:58.346799541Z",
+        "Type": "NORMAL",
+        "Networks": [
+          {
+            "NetworkMode": "awsvpc",
+            "IPv4Addresses": [
+              "172.17.0.2"
+            ]
+          }
+        ]
+      }
+    ]
+  }
+  

--- a/platform/types.go
+++ b/platform/types.go
@@ -12,4 +12,6 @@ const (
 	Kubernetes   Type = "kubernetes"
 	EKSOnFargate Type = "eks_fargate"
 	None         Type = "none"
+	// experimental
+	ECSExternal Type = "ecs_external"
 )


### PR DESCRIPTION
# why

I want to use mackerel-container-agent with ECS Tasks running on ECS Anywhere

# what / how 

Now works on ECS Anywhere. There are two changes.

1. From `MACKEREL_CONTAINER_PLATFORM`, it is known to be running on ECS Anywhere.

2. (Unlike other ECS Tasks) Implemented a workaround because `AWS_EXECUTION_ENV` cannot be obtained

# how to use

Mostly the same as https://mackerel.io/docs/entry/howto/install-agent/container/ecs.
Set `MACKEREL_CONTAINER_PLATFORM` to`ecs_external`.

# For reviewers

I think this is an experimental function. There are three reasons.

1. In operation with ECS Anywhere, we have only confirmed the operation in the environment we are using.
2. mackerel-container-agent assumes that there is `AWS_EXECUTION_ENV`, but this time it did not exist, so it is forcibly avoided.
    - It's a good idea to check the `launchType` that is returned from`${ECS_CONTAINER_METADATA_URI}/tasks`. However, with mackerel-container-agent, the platform and provider were decided first, and then the metadata endpoint was selected, which made implementation difficult and abandoned.
3. This is because ECS metadata will not be expanded on mackerel.io unless the reception support for `platform.ECSExternal` and `externalProvider` is made on the mackerel.io side.

# Operation check

- After embedding an instance prepared outside of AWS and running it as an ECS Anywhere instance, I've verified that it actually works on the ECS Anywhere task.
  - Use the metadata that can be seen during operation as the source of test data.
- I have confirmed that `make test` is OK.