### PR TITLE
refactoring agent/platform.go

### DIFF
--- a/agent/platform.go
+++ b/agent/platform.go
@@ -42,7 +42,7 @@ func NewPlatform(ctx context.Context, ignoreContainer *regexp.Regexp) (platform.
 		if err != nil {
 			return nil, err
 		}
-		executionEnv := ecs.ExecutionEnvECSAnywhere
+		executionEnv := ecs.ExecutionEnvECSExternal
 		return ecs.NewECSPlatform(ctx, metadataURI, executionEnv, ignoreContainer)
 
 	case platform.Kubernetes:

--- a/platform/ecs/ecs.go
+++ b/platform/ecs/ecs.go
@@ -22,8 +22,8 @@ const (
 	executionEnvFargate = "AWS_ECS_FARGATE"
 	executionEnvEC2     = "AWS_ECS_EC2"
 
-	// ExecutionEnvECSAnywhere : (experimental) It is a definition that is handled internally, not an environment variable.
-	ExecutionEnvECSAnywhere = "ECS_ANYWHERE"
+	// ExecutionEnvECSExternal : (experimental) It is a definition that is handled internally, not an environment variable.
+	ExecutionEnvECSExternal = "ECS_EXTERNAL"
 )
 
 var (
@@ -126,7 +126,7 @@ func resolveProvider(executionEnv string) (provider, error) {
 		return fargateProvider, nil
 	case executionEnvEC2:
 		return ecsProvider, nil
-	case ExecutionEnvECSAnywhere:
+	case ExecutionEnvECSExternal:
 		return ecsAnywhereProvider, nil
 	default:
 		return provider("UNKNOWN"), fmt.Errorf("unknown execution env: %q", executionEnv)

--- a/platform/ecs/ecs_test.go
+++ b/platform/ecs/ecs_test.go
@@ -39,7 +39,7 @@ func TestResolveProvider(t *testing.T) {
 	}{
 		{"AWS_ECS_FARGATE", fargateProvider},
 		{"AWS_ECS_EC2", ecsProvider},
-		{"ECS_ANYWHERE", ecsAnywhereProvider},
+		{"ECS_EXTERNAL", ecsAnywhereProvider},
 		{"unknown", provider("UNKNOWN")},
 		{"", provider("UNKNOWN")},
 	}


### PR DESCRIPTION
- rename from ExecutionEnvECSAnywhere to ExecutionEnvECSExternal
- refactoring agent/platform.go