### PR TITLE
refactor: replace ioutil functions

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -3,7 +3,6 @@ package agent
 import (
 	"context"
 	"errors"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -85,8 +84,7 @@ func init() {
 }
 
 func TestAgentRun_RetryMetricPost(t *testing.T) {
-	dir, _ := ioutil.TempDir("", "mackerel-container-agent-run-test-retry")
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	conf := &config.Config{Root: dir}
 	hostID := "abcde"
 	var postedMetricValues []*mackerel.MetricValue
@@ -130,8 +128,7 @@ func TestAgentRun_RetryMetricPost(t *testing.T) {
 }
 
 func TestAgentRun_ResolveHostIdLazy(t *testing.T) {
-	dir, _ := ioutil.TempDir("", "mackerel-container-agent-run-test-lazy")
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	conf := &config.Config{Root: dir}
 	hostID := "abcde"
 	var updatedCount int
@@ -203,8 +200,7 @@ func TestAgentRun_ResolveHostIdLazy(t *testing.T) {
 }
 
 func TestAgentRun_NoRetryBadRequest(t *testing.T) {
-	dir, _ := ioutil.TempDir("", "mackerel-container-agent-run-test-bad-request")
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	conf := &config.Config{Root: dir}
 	hostID := "abcde"
 
@@ -230,8 +226,7 @@ func TestAgentRun_NoRetryBadRequest(t *testing.T) {
 }
 
 func TestAgentRun_Retire(t *testing.T) {
-	dir, _ := ioutil.TempDir("", "mackerel-container-agent-run-test-retire")
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	conf := &config.Config{Root: dir}
 	hostID := "abcde"
 
@@ -269,8 +264,7 @@ func TestAgentRun_Retire(t *testing.T) {
 }
 
 func TestAgentRun_Retire_Retry(t *testing.T) {
-	dir, _ := ioutil.TempDir("", "mackerel-container-agent-run-test-retire-retry")
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	conf := &config.Config{Root: dir}
 	hostID := "abcde"
 
@@ -316,8 +310,7 @@ func TestAgentRun_Retire_Retry(t *testing.T) {
 }
 
 func TestAgentRun_Retire_HostIDError(t *testing.T) {
-	dir, _ := ioutil.TempDir("", "mackerel-container-agent-run-test-retire-hostid-error")
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	conf := &config.Config{Root: dir}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -354,8 +347,7 @@ func TestAgentRun_Retire_HostIDError(t *testing.T) {
 }
 
 func TestAgentRun_MetricPlugin(t *testing.T) {
-	dir, _ := ioutil.TempDir("", "mackerel-container-agent-run-test-metric-plugin")
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	conf := &config.Config{
 		Root: dir,
 		MetricPlugins: []*config.MetricPlugin{
@@ -410,8 +402,7 @@ func TestAgentRun_MetricPlugin(t *testing.T) {
 }
 
 func TestAgentRun_CustomIdentifier(t *testing.T) {
-	dir, _ := ioutil.TempDir("", "mackerel-container-agent-run-test-custom-identifier")
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	conf := &config.Config{Root: dir}
 	hostID := "abcde"
 	customIdentifier := "custom-identifier-abcde"
@@ -462,8 +453,7 @@ func TestAgentRun_CustomIdentifier(t *testing.T) {
 }
 
 func TestAgentRun_CustomIdentifier_CreateHost(t *testing.T) {
-	dir, _ := ioutil.TempDir("", "mackerel-container-agent-run-test-custom-identifier-create-host")
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	conf := &config.Config{Root: dir}
 	hostID := "abcde"
 	customIdentifier := "custom-identifier-abcde"
@@ -517,14 +507,15 @@ func TestAgentRun_CustomIdentifier_CreateHost(t *testing.T) {
 }
 
 func TestAgentRun_HostIDFile(t *testing.T) {
-	dir, _ := ioutil.TempDir("", "mackerel-container-agent-run-test-lazy")
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	conf := &config.Config{Root: dir}
 	hostID := "abcde"
 	var updatedCount int
 	var postedReports []*mackerel.CheckReports
 
-	ioutil.WriteFile(filepath.Join(dir, "id"), []byte(hostID), 0600)
+	if err := os.WriteFile(filepath.Join(dir, "id"), []byte(hostID), 0600); err != nil {
+		t.Fatal(err)
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
 	defer cancel()
 	client := api.NewMockClient(
@@ -596,8 +587,7 @@ func (g *mockSpecGeneratorStatus) Generate(context.Context) (interface{}, error)
 }
 
 func TestAgentRun_StatusRunning(t *testing.T) {
-	dir, _ := ioutil.TempDir("", "mackerel-container-agent-run-test-status-running")
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	conf := &config.Config{Root: dir}
 	hostID := "abcde"
 	pform := &mockPlatformStatusRunning{count: 2}
@@ -627,8 +617,7 @@ func TestAgentRun_StatusRunning(t *testing.T) {
 }
 
 func TestAgentRun_ReadinessProbe(t *testing.T) {
-	dir, _ := ioutil.TempDir("", "mackerel-container-agent-run-test-readiness-probe")
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	conf := &config.Config{
 		Root: dir,
 		ReadinessProbe: &config.Probe{
@@ -666,8 +655,7 @@ func TestAgentRun_ReadinessProbe(t *testing.T) {
 }
 
 func TestAgentRun_ReadinessProbe_SleepLong(t *testing.T) {
-	dir, _ := ioutil.TempDir("", "mackerel-container-agent-run-test-readiness-probe-sleep-long")
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	conf := &config.Config{
 		Root: dir,
 		ReadinessProbe: &config.Probe{
@@ -694,8 +682,7 @@ func TestAgentRun_ReadinessProbe_SleepLong(t *testing.T) {
 }
 
 func TestAgentRun_HostStatusOnStart(t *testing.T) {
-	dir, _ := ioutil.TempDir("", "mackerel-container-agent-run-test-host-status-on-start")
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	conf := &config.Config{
 		Root:              dir,
 		HostStatusOnStart: mackerel.HostStatusWorking,

--- a/agent/host_resolver.go
+++ b/agent/host_resolver.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -26,7 +25,7 @@ func newHostResolver(client api.Client, root string) *hostResolver {
 
 func (r *hostResolver) getHost(hostParam *mackerel.CreateHostParam) (*mackerel.Host, bool, error) {
 	var host *mackerel.Host
-	content, err := ioutil.ReadFile(r.path)
+	content, err := os.ReadFile(r.path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			// host id file not found
@@ -85,7 +84,7 @@ func (r *hostResolver) getHost(hostParam *mackerel.CreateHostParam) (*mackerel.H
 }
 
 func (r *hostResolver) getLocalHostID() (string, error) {
-	content, err := ioutil.ReadFile(r.path)
+	content, err := os.ReadFile(r.path)
 	if err != nil {
 		return "", err
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -186,7 +186,7 @@ func fetch(ctx context.Context, location string) ([]byte, error) {
 }
 
 func fetchFile(path string) ([]byte, error) {
-	return ioutil.ReadFile(path)
+	return os.ReadFile(path)
 }
 
 func fetchHTTP(ctx context.Context, u *url.URL) ([]byte, error) {
@@ -205,7 +205,7 @@ func fetchHTTP(ctx context.Context, u *url.URL) ([]byte, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
-	return ioutil.ReadAll(resp.Body)
+	return io.ReadAll(resp.Body)
 }
 
 func parseRoles(value string) []string {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"context"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -697,7 +696,7 @@ func newHTTPServer(content string) *httptest.Server {
 }
 
 func newConfigFile(content string) (*os.File, error) {
-	temp, err := ioutil.TempFile("", "mackerel-config-test")
+	temp, err := os.CreateTemp("", "mackerel-config-test")
 	if err != nil {
 		return nil, err
 	}

--- a/config/loader_test.go
+++ b/config/loader_test.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -88,7 +87,7 @@ root: '/tmp/mackerel-container-agent'
 	errCh := make(chan error)
 	go func() {
 		time.Sleep(800 * time.Millisecond)
-		errCh <- ioutil.WriteFile(file.Name(), []byte(`
+		errCh <- os.WriteFile(file.Name(), []byte(`
 apikey: 'DUMMY APIKEY 2'
 root: '/tmp/mackerel-container-agent'
 plugin:

--- a/platform/ecs/taskmetadata/client.go
+++ b/platform/ecs/taskmetadata/client.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"path"
@@ -121,7 +121,7 @@ func (c *Client) newRequest(endpoint string) (*http.Request, error) {
 func decodeBody(resp *http.Response, out interface{}) error {
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("got status code %d (url: %s, body: %q)", resp.StatusCode, resp.Request.URL, body)
 	}
 	return json.NewDecoder(resp.Body).Decode(out)

--- a/platform/kubernetes/kubelet/client.go
+++ b/platform/kubernetes/kubelet/client.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"path"
@@ -151,7 +151,7 @@ func (c *client) newRequest(endpoint string) (*http.Request, error) {
 func decodeBody(resp *http.Response, out interface{}) error {
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("got status code %d (url: %s, body: %q)", resp.StatusCode, resp.Request.URL, body)
 	}
 	return json.NewDecoder(resp.Body).Decode(out)

--- a/platform/kubernetes/kubernetes.go
+++ b/platform/kubernetes/kubernetes.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"path"
 	"regexp"
 	"strings"
@@ -48,12 +48,12 @@ func NewKubernetesPlatform(kubeletHost, kubeletPort string, useReadOnlyPort, ins
 
 		var err error
 
-		caCert, err = ioutil.ReadFile(caCertificateFile)
+		caCert, err = os.ReadFile(caCertificateFile)
 		if err != nil {
 			return nil, err
 		}
 
-		token, err = ioutil.ReadFile(tokenFile)
+		token, err = os.ReadFile(tokenFile)
 		if err != nil {
 			return nil, err
 		}
@@ -87,12 +87,12 @@ func NewEKSOnFargatePlatform(kubernetesHost, kubernetesPort string, namespace, p
 		Path:   path.Join("api", "v1", "nodes", nodeName, "proxy"),
 	}
 
-	caCert, err = ioutil.ReadFile(caCertificateFile)
+	caCert, err = os.ReadFile(caCertificateFile)
 	if err != nil {
 		return nil, err
 	}
 
-	token, err = ioutil.ReadFile(tokenFile)
+	token, err = os.ReadFile(tokenFile)
 	if err != nil {
 		return nil, err
 	}

--- a/platform/kubernetes/metric_test.go
+++ b/platform/kubernetes/metric_test.go
@@ -3,7 +3,7 @@ package kubernetes
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"reflect"
 	"testing"
 
@@ -20,7 +20,7 @@ func TestGenerateStats(t *testing.T) {
 	ctx := context.Background()
 	client := kubelet.NewMockClient(
 		kubelet.MockGetPod(func(context.Context) (*kubernetesTypes.Pod, error) {
-			raw, err := ioutil.ReadFile("kubelet/testdata/pods.json")
+			raw, err := os.ReadFile("kubelet/testdata/pods.json")
 			if err != nil {
 				return nil, err
 			}
@@ -36,7 +36,7 @@ func TestGenerateStats(t *testing.T) {
 			return nil, nil
 		}),
 		kubelet.MockGetPodStats(func(context.Context) (*kubeletTypes.PodStats, error) {
-			raw, err := ioutil.ReadFile("kubelet/testdata/summary.json")
+			raw, err := os.ReadFile("kubelet/testdata/summary.json")
 			if err != nil {
 				return nil, err
 			}

--- a/platform/kubernetes/spec_test.go
+++ b/platform/kubernetes/spec_test.go
@@ -3,7 +3,7 @@ package kubernetes
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -20,7 +20,7 @@ import (
 func TestGenerateSpec(t *testing.T) {
 	client := kubelet.NewMockClient(
 		kubelet.MockGetPod(func(context.Context) (*kubernetesTypes.Pod, error) {
-			raw, err := ioutil.ReadFile("kubelet/testdata/pods.json")
+			raw, err := os.ReadFile("kubelet/testdata/pods.json")
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
I changed all functions provided in **io/ioutil** to the corresponding to.

Note: **testing.T.TempDir** is added in Go 1.15.