### PR TITLE
Improve `NewPlatform` error messages

### DIFF
--- a/agent/platform.go
+++ b/agent/platform.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"regexp"
@@ -16,7 +15,10 @@ import (
 
 // NewPlatform creates a new container platform
 func NewPlatform(ctx context.Context, ignoreContainer *regexp.Regexp) (platform.Platform, error) {
-	p := os.Getenv("MACKEREL_CONTAINER_PLATFORM")
+	p, err := getEnvValue("MACKEREL_CONTAINER_PLATFORM")
+	if err != nil {
+		return nil, err
+	}
 
 	switch platform.Type(p) {
 
@@ -101,7 +103,7 @@ func NewPlatform(ctx context.Context, ignoreContainer *regexp.Regexp) (platform.
 		return none.NewNonePlatform()
 
 	default:
-		return nil, errors.New("platform not specified")
+		return nil, fmt.Errorf("%q platform is invalid. please check your MACKEREL_CONTAINER_PLATFORM", p)
 	}
 }
 


### PR DESCRIPTION
Before:
![スクリーンショット 2022-09-30 16 02 29](https://user-images.githubusercontent.com/50798936/193210591-0d1d571e-44f3-4a7f-af5a-2820dd01aa7f.png)

After:
```zsh
~/Desktop/mackerel-container-agent
$ ./build/mackerel-container-agent 
2022/09/30 15:58:07 INFO <main> starting mackerel-container-agent (version:0.7.2, revision:af2cc21)
2022/09/30 15:58:07 ERROR <main> MACKEREL_CONTAINER_PLATFORM environment variable is not set
~/Desktop/mackerel-container-agent
$ export MACKEREL_CONTAINER_PLATFORM=foo
~/Desktop/mackerel-container-agent
$ ./build/mackerel-container-agent      
2022/09/30 15:58:25 INFO <main> starting mackerel-container-agent (version:0.7.2, revision:af2cc21)
2022/09/30 15:58:25 ERROR <main> "foo" platform is invalid. please check your MACKEREL_CONTAINER_PLATFORM
```