### PR TITLE
Replace interface{} to any

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -580,7 +580,7 @@ type mockSpecGeneratorStatus struct {
 	pform *mockPlatformStatusRunning
 }
 
-func (g *mockSpecGeneratorStatus) Generate(context.Context) (interface{}, error) {
+func (g *mockSpecGeneratorStatus) Generate(context.Context) (any, error) {
 	return &mackerel.Cloud{
 		MetaData: map[string]string{"status": g.pform.Status()},
 	}, nil

--- a/cmdutil/command.go
+++ b/cmdutil/command.go
@@ -8,11 +8,11 @@ import (
 
 // Command represents a plugin/probe command to allow string and []string.
 type Command struct {
-	command interface{}
+	command any
 }
 
 // UnmarshalYAML defines unmarshaler from YAML.
-func (c *Command) UnmarshalYAML(unmarshal func(v interface{}) error) (err error) {
+func (c *Command) UnmarshalYAML(unmarshal func(v any) error) (err error) {
 	var s string
 	if err := unmarshal(&s); err == nil {
 		c.command = s

--- a/config/env.go
+++ b/config/env.go
@@ -10,7 +10,7 @@ import (
 type Env []string
 
 // UnmarshalYAML defines unmarshaler from YAML
-func (env *Env) UnmarshalYAML(unmarshal func(v interface{}) error) (err error) {
+func (env *Env) UnmarshalYAML(unmarshal func(v any) error) (err error) {
 	var envMap map[string]string
 	if err = unmarshal(&envMap); err != nil {
 		return err

--- a/docs/architecture.dot
+++ b/docs/architecture.dot
@@ -27,7 +27,7 @@ digraph {
   subgraph spec {
     label="spec";
     "spec.Manager" -> "spec.collector" [dir=back label="mackerel.HostMeta"];
-    "spec.collector" -> "[]spec.Generator" [dir=back label="interface{}"];
+    "spec.collector" -> "[]spec.Generator" [dir=back label="any"];
     "spec.Manager" -> "spec.sender" [label="*mackerel.UpdateHostParam"];
   }
 

--- a/docs/architecture.svg
+++ b/docs/architecture.svg
@@ -289,7 +289,7 @@
 <title>spec.collector&#45;&gt;[]spec.Generator</title>
 <path fill="none" stroke="#000000" d="M605.3968,-399C655.1222,-399 721.9055,-399 771.6803,-399"/>
 <polygon fill="#000000" stroke="#000000" points="605.3735,-395.5001 595.3735,-399 605.3735,-402.5001 605.3735,-395.5001"/>
-<text text-anchor="middle" x="687.431" y="-401.8" font-family="Times,serif" font-size="14.00" fill="#000000">interface{}</text>
+<text text-anchor="middle" x="687.431" y="-401.8" font-family="Times,serif" font-size="14.00" fill="#000000">any</text>
 </g>
 <!-- spec.sender&#45;&gt;api.Client -->
 <g id="edge26" class="edge">

--- a/platform/ecs/spec.go
+++ b/platform/ecs/spec.go
@@ -29,7 +29,7 @@ func newSpecGenerator(client TaskMetadataGetter, provider provider) *specGenerat
 	}
 }
 
-func (g *specGenerator) Generate(ctx context.Context) (interface{}, error) {
+func (g *specGenerator) Generate(ctx context.Context) (any, error) {
 	meta, err := g.client.GetTaskMetadata(ctx)
 	if err != nil {
 		return nil, err

--- a/platform/ecs/taskmetadata/client.go
+++ b/platform/ecs/taskmetadata/client.go
@@ -118,7 +118,7 @@ func (c *Client) newRequest(endpoint string) (*http.Request, error) {
 	return http.NewRequest("GET", u.String(), nil)
 }
 
-func decodeBody(resp *http.Response, out interface{}) error {
+func decodeBody(resp *http.Response, out any) error {
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)

--- a/platform/kubernetes/kubelet/client.go
+++ b/platform/kubernetes/kubelet/client.go
@@ -148,7 +148,7 @@ func (c *client) newRequest(endpoint string) (*http.Request, error) {
 	return req, nil
 }
 
-func decodeBody(resp *http.Response, out interface{}) error {
+func decodeBody(resp *http.Response, out any) error {
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)

--- a/platform/kubernetes/spec.go
+++ b/platform/kubernetes/spec.go
@@ -81,7 +81,7 @@ func newSpecGenerator(client kubelet.Client) *specGenerator {
 		client: client,
 	}
 }
-func (g *specGenerator) Generate(ctx context.Context) (interface{}, error) {
+func (g *specGenerator) Generate(ctx context.Context) (any, error) {
 	p, err := g.client.GetPod(ctx)
 	if err != nil {
 		return nil, err

--- a/spec/cpu.go
+++ b/spec/cpu.go
@@ -17,11 +17,11 @@ type CPUGenerator struct {
 
 var cpuLogger = logging.GetLogger("spec.cpu")
 
-func (g *CPUGenerator) generate(file io.Reader) (interface{}, error) {
+func (g *CPUGenerator) generate(file io.Reader) (any, error) {
 	scanner := bufio.NewScanner(file)
 
 	var results mackerel.CPU
-	var cpuinfo map[string]interface{}
+	var cpuinfo map[string]any
 	var modelName string
 
 	for scanner.Scan() {
@@ -35,7 +35,7 @@ func (g *CPUGenerator) generate(file io.Reader) (interface{}, error) {
 
 		switch key {
 		case "processor":
-			cpuinfo = make(map[string]interface{})
+			cpuinfo = make(map[string]any)
 			if modelName != "" {
 				cpuinfo["model_name"] = modelName
 			}
@@ -62,7 +62,7 @@ func (g *CPUGenerator) generate(file io.Reader) (interface{}, error) {
 
 	// Old kernels with CONFIG_SMP disabled has no "processor: " line
 	if len(results) == 0 && modelName != "" {
-		cpuinfo = make(map[string]interface{})
+		cpuinfo = make(map[string]any)
 		cpuinfo["model_name"] = modelName
 		results = append(results, cpuinfo)
 	}
@@ -71,7 +71,7 @@ func (g *CPUGenerator) generate(file io.Reader) (interface{}, error) {
 }
 
 // Generate CPU specs
-func (g *CPUGenerator) Generate(ctx context.Context) (interface{}, error) {
+func (g *CPUGenerator) Generate(ctx context.Context) (any, error) {
 	file, err := os.Open("/proc/cpuinfo")
 	if err != nil {
 		// Don't return error to prevent stop agent

--- a/spec/generator.go
+++ b/spec/generator.go
@@ -8,7 +8,7 @@ import (
 
 // Generator interface generates spec information
 type Generator interface {
-	Generate(context.Context) (interface{}, error)
+	Generate(context.Context) (any, error)
 }
 
 // CloudHostname has mackerel.Cloud and host name

--- a/spec/mock_generator.go
+++ b/spec/mock_generator.go
@@ -4,16 +4,16 @@ import "context"
 
 // MockGenerator represents a mock spec generator
 type MockGenerator struct {
-	value    interface{}
+	value    any
 	errValue error
 }
 
 // NewMockGenerator creates a new mock spec generator
-func NewMockGenerator(value interface{}, errValue error) Generator {
+func NewMockGenerator(value any, errValue error) Generator {
 	return &MockGenerator{value, errValue}
 }
 
 // Generate generates spec values
-func (g *MockGenerator) Generate(context.Context) (interface{}, error) {
+func (g *MockGenerator) Generate(context.Context) (any, error) {
 	return g.value, g.errValue
 }


### PR DESCRIPTION
In go 1.18 and above, we can replace `interface{}` to `any` alias for ease of understanding.