### PR TITLE
replace deprecated apt-key command on Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ ENV MKR_INSTALL_PLUGINS json
 
 RUN apt-get update -yq && \
     apt-get install -yq --no-install-recommends curl gnupg2
-RUN curl -sS https://mackerel.io/file/cert/GPG-KEY-mackerel-v2 | sudo gpg --dearmor -o /etc/apt/keyrings/mackerel.gpg
+RUN curl -sS https://mackerel.io/file/cert/GPG-KEY-mackerel-v2 | gpg --dearmor -o /etc/apt/keyrings/mackerel.gpg
 RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/mackerel.gpg] http://apt.mackerel.io/v2/ mackerel contrib" > /etc/apt/sources.list.d/mackerel.list
 
 RUN apt-get update -yq && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,8 @@ ENV MKR_INSTALL_PLUGINS json
 
 RUN apt-get update -yq && \
     apt-get install -yq --no-install-recommends curl gnupg2
-RUN echo "deb [arch=amd64,arm64] http://apt.mackerel.io/v2/ mackerel contrib" > /etc/apt/sources.list.d/mackerel.list
-RUN curl -LfsS https://mackerel.io/file/cert/GPG-KEY-mackerel-v2 | apt-key add -
+RUN curl -sS https://mackerel.io/file/cert/GPG-KEY-mackerel-v2 | sudo gpg --dearmor -o /etc/apt/keyrings/mackerel.gpg
+RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/mackerel.gpg] http://apt.mackerel.io/v2/ mackerel contrib" > /etc/apt/sources.list.d/mackerel.list
 
 RUN apt-get update -yq && \
     apt-get install -yq --no-install-recommends mackerel-agent-plugins mackerel-check-plugins mkr && \


### PR DESCRIPTION
`apt-key` command is now deprecated so I replaced it to `signed-by` option.

```console
$ docker build
[+] Building 38.4s (22/22) FINISHED                                                                     docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                    0.0s
 => => transferring dockerfile: 1.91kB                                                                                  0.0s
 => [internal] load metadata for docker.io/library/debian:bookworm-slim                                                 2.9s
 => [internal] load metadata for docker.io/library/golang:1.22-bookworm                                                 2.9s
 => [internal] load .dockerignore                                                                                       0.0s
 => => transferring context: 2B                                                                                         0.0s
 => [builder 1/6] FROM docker.io/library/golang:1.22-bookworm@sha256:6d71b7c3f884e7b9552bffa852d938315ecca843dcc75a86e  9.0s
 => => resolve docker.io/library/golang:1.22-bookworm@sha256:6d71b7c3f884e7b9552bffa852d938315ecca843dcc75a86ee7000567  0.0s
 => => sha256:4e4b5ba5a750ca26a8277c4394180b48e8b42ca841be18085952cdd5f12a599e 1.79kB / 1.79kB                          0.0s
 => => sha256:353c80fdbef13719285eb0463a9a6c7769df89a3797e79ac8a52a93f85b67c3f 86.45MB / 86.45MB                        3.8s
 => => sha256:6d71b7c3f884e7b9552bffa852d938315ecca843dcc75a86ee7000567da0923d 1.64kB / 1.64kB                          0.0s
 => => sha256:dbf949409606fe05ee3766af0b860016c92fe514b9195e60ebb3ad369972cf93 2.89kB / 2.89kB                          0.0s
 => => sha256:fbfbb5ee3ce6fdaeec555edeaa10a90bec717d10a3f3902831e6a203183eadc0 66.27MB / 66.27MB                        5.7s
 => => sha256:381af5b45fb7f0bf4199216d30c0ce356e8603d232eb5dbda10fb12540dd3c26 175B / 175B                              3.4s
 => => sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1 32B / 32B                                3.7s
 => => extracting sha256:353c80fdbef13719285eb0463a9a6c7769df89a3797e79ac8a52a93f85b67c3f                               1.5s
 => => extracting sha256:fbfbb5ee3ce6fdaeec555edeaa10a90bec717d10a3f3902831e6a203183eadc0                               3.0s
 => => extracting sha256:381af5b45fb7f0bf4199216d30c0ce356e8603d232eb5dbda10fb12540dd3c26                               0.0s
 => => extracting sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1                               0.0s
 => [container-agent 1/3] FROM docker.io/library/debian:bookworm-slim@sha256:155280b00ee0133250f7159b567a07d7cd03b1645  4.2s
 => => resolve docker.io/library/debian:bookworm-slim@sha256:155280b00ee0133250f7159b567a07d7cd03b1645714c3a7458b2287b  0.0s
 => => sha256:155280b00ee0133250f7159b567a07d7cd03b1645714c3a7458b2287b0ca83cb 1.85kB / 1.85kB                          0.0s
 => => sha256:c75bd6810361193340244d757f53b44d13bb9055772959a2f02e89efa2ad9bd2 529B / 529B                              0.0s
 => => sha256:0857b823787b84f98b8b284832e923f0b9586be8ebc8addcc009245c945aa800 1.48kB / 1.48kB                          0.0s
 => => sha256:22d97f6a5d13532e867231d23d92620a81874d51a456196be50154eeb32edc08 29.18MB / 29.18MB                        3.1s
 => => extracting sha256:22d97f6a5d13532e867231d23d92620a81874d51a456196be50154eeb32edc08                               1.0s
 => [internal] load build context                                                                                       0.1s
 => => transferring context: 247.63kB                                                                                   0.1s
 => [container-agent 2/3] RUN apt-get update -yq &&     apt-get install -yq --no-install-recommends ca-certificates su  6.2s
 => [builder 2/6] WORKDIR /go/src/app                                                                                   0.5s
 => [builder 3/6] COPY go.sum go.mod ./                                                                                 0.0s
 => [builder 4/6] RUN go mod download                                                                                   6.5s
 => [builder 5/6] COPY . .                                                                                              0.1s
 => [builder 6/6] RUN make build                                                                                        7.9s
 => [container-agent 3/3] COPY --from=builder /go/src/app/build/mackerel-container-agent /usr/local/bin/                0.0s
 => [container-agent-with-plugins 1/7] RUN apt-get update -yq &&     apt-get install -yq --no-install-recommends curl   4.3s
 => [container-agent-with-plugins 2/7] RUN curl -sS https://mackerel.io/file/cert/GPG-KEY-mackerel-v2 | sudo gpg --dea  0.4s
 => [container-agent-with-plugins 3/7] RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/ma  0.3s
 => [container-agent-with-plugins 4/7] RUN apt-get update -yq &&     apt-get install -yq --no-install-recommends macke  3.1s
 => [container-agent-with-plugins 5/7] RUN find /usr/bin/ -type l -regextype posix-egrep -name 'mackerel-plugin-*' -a   0.3s
 => [container-agent-with-plugins 6/7] RUN find /usr/bin/ -type l -regextype posix-egrep -name 'check-*' -a ! -regex "  0.3s
 => [container-agent-with-plugins 7/7] RUN echo json | tr ' ' '\n' | xargs -I@ mkr plugin install mackerel-plugin-@     2.4s
 => exporting to image                                                                                                  0.1s
 => => exporting layers                                                                                                 0.1s
 => => writing image sha256:4082cd61ac2f21aaf8d2aeab922d5407bbefbd03f4157d05c9f091cff3b69b23                            0.0s

What's Next?
  View a summary of image vulnerabilities and recommendations → docker scout quickview
```