### PR TITLE
update github.com/docker/docker

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.29.16
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.17.79
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.80.2
-	github.com/docker/docker v26.1.5+incompatible
+	github.com/docker/docker v28.3.3+incompatible
 	github.com/mackerelio/go-osstat v0.2.6
 	github.com/mackerelio/golib v1.2.1
 	github.com/mackerelio/mackerel-client-go v0.37.2
@@ -54,7 +54,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.2 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -46,8 +46,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/docker/docker v26.1.5+incompatible h1:NEAxTwEjxV6VbBMBoGG3zPqbiJosIApZjxlbrG9q3/g=
-github.com/docker/docker v26.1.5+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v28.3.3+incompatible h1:Dypm25kh4rmk49v1eiVbsAtpAsYURjYkaKubwuBdxEI=
+github.com/docker/docker v28.3.3+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=
@@ -95,8 +95,6 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.0.2 h1:9yCKha/T5XdGtO0q9Q9a6T5NUCsTn/DrBg0D7ufOcFM=
 github.com/opencontainers/image-spec v1.0.2/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF4JjgDlrVEn3C11VoGHZN7m8qihwgMEtzYw=

--- a/platform/ecs/metric_test.go
+++ b/platform/ecs/metric_test.go
@@ -8,7 +8,7 @@ import (
 	"reflect"
 	"testing"
 
-	dockerTypes "github.com/docker/docker/api/types"
+	dockerTypes "github.com/docker/docker/api/types/container"
 	ecsTypes "github.com/mackerelio/mackerel-container-agent/internal/amazon-ecs-agent/agent/handlers/v2"
 
 	"github.com/mackerelio/mackerel-container-agent/metric"
@@ -33,14 +33,14 @@ func (m *mockTaskMetadataEndpointClient) GetTaskMetadata(ctx context.Context) (*
 	return &res, nil
 }
 
-func (m *mockTaskMetadataEndpointClient) GetTaskStats(ctx context.Context) (map[string]*dockerTypes.StatsJSON, error) {
+func (m *mockTaskMetadataEndpointClient) GetTaskStats(ctx context.Context) (map[string]*dockerTypes.StatsResponse, error) {
 	f, err := os.Open(m.statsPath)
 	if err != nil {
 		return nil, err
 	}
 	defer f.Close()
 
-	var res map[string]*dockerTypes.StatsJSON
+	var res map[string]*dockerTypes.StatsResponse
 	if err := json.NewDecoder(f).Decode(&res); err != nil {
 		return nil, err
 	}

--- a/platform/ecs/taskmetadata/client.go
+++ b/platform/ecs/taskmetadata/client.go
@@ -11,7 +11,7 @@ import (
 	"regexp"
 	"time"
 
-	dockerTypes "github.com/docker/docker/api/types"
+	dockerTypes "github.com/docker/docker/api/types/container"
 	ecsTypes "github.com/mackerelio/mackerel-container-agent/internal/amazon-ecs-agent/agent/handlers/v2"
 )
 
@@ -82,7 +82,7 @@ func (c *Client) GetTaskMetadata(ctx context.Context) (*ecsTypes.TaskResponse, e
 }
 
 // GetTaskStats gets task stats
-func (c *Client) GetTaskStats(ctx context.Context) (map[string]*dockerTypes.StatsJSON, error) {
+func (c *Client) GetTaskStats(ctx context.Context) (map[string]*dockerTypes.StatsResponse, error) {
 	req, err := c.newRequest(statsPath)
 	if err != nil {
 		return nil, err
@@ -91,7 +91,7 @@ func (c *Client) GetTaskStats(ctx context.Context) (map[string]*dockerTypes.Stat
 	if err != nil {
 		return nil, err
 	}
-	var all map[string]*dockerTypes.StatsJSON
+	var all map[string]*dockerTypes.StatsResponse
 	if err = decodeBody(resp, &all); err != nil {
 		return nil, err
 	}
@@ -101,7 +101,7 @@ func (c *Client) GetTaskStats(ctx context.Context) (map[string]*dockerTypes.Stat
 		return nil, err
 	}
 
-	res := make(map[string]*dockerTypes.StatsJSON)
+	res := make(map[string]*dockerTypes.StatsResponse)
 
 	for _, container := range meta.Containers {
 		if v, ok := all[container.ID]; ok {


### PR DESCRIPTION
The [dependabot PR](https://github.com/mackerelio/mackerel-container-agent/pull/467) caused CI to fail.
This was due to code moves within github.com/docker/docker.
Manual action was required, so we did it.

https://github.com/moby/moby/commit/0a4277abf487c6ecbfaedfcf731bce6140e68678

