### PR TITLE
Fix deprecated workflow command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Get alpha version from branch name
         id: get_alpha_version
-        run: echo "::set-output name=VERSION::${GITHUB_HEAD_REF/bump-version-/v}"
+        run: echo "VERSION=${GITHUB_HEAD_REF/bump-version-/v}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push alpha image
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
@@ -148,7 +148,7 @@ jobs:
 
       - name: Get version from tag
         id: get_version
-        run: echo "::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}"
+        run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push release image
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0


### PR DESCRIPTION
Title says it all. Ref: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
