### PR TITLE
Deduplicate env masking into config.Env.Masked method

### DIFF
--- a/check/plugin.go
+++ b/check/plugin.go
@@ -2,7 +2,6 @@ package check
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	mackerel "github.com/mackerelio/mackerel-client-go"
@@ -29,13 +28,7 @@ func (g *pluginGenerator) Config() mackerel.CheckConfig {
 // Generate generates check report
 func (g *pluginGenerator) Generate(ctx context.Context) (*Result, error) {
 	now := time.Now()
-	var masked_env []string
-	for _, v := range g.Env {
-		key := strings.Split(v, "=")[0]
-		value := strings.Split(v, "=")[1]
-		masked_env = append(masked_env, key+"="+config.MaskEnvValue(value))
-	}
-	logger.Debugf("plugin %s command: %s env: %+v", g.Name, g.Command, masked_env)
+	logger.Debugf("plugin %s command: %s env: %+v", g.Name, g.Command, g.Env.Masked())
 	stdout, stderr, exitCode, err := cmdutil.RunCommand(ctx, g.Command, g.User, g.Env, g.Timeout)
 
 	if stderr != "" {

--- a/config/env.go
+++ b/config/env.go
@@ -40,6 +40,19 @@ func buildEnv(envMap map[string]string) ([]string, error) {
 	return env, nil
 }
 
+// Masked returns the environment variables with their values masked for logging.
+func (env Env) Masked() []string {
+	if len(env) == 0 {
+		return nil
+	}
+	masked := make([]string, len(env))
+	for i, v := range env {
+		key, value, _ := strings.Cut(v, "=")
+		masked[i] = key + "=" + MaskEnvValue(value)
+	}
+	return masked
+}
+
 // MaskEnvValue return masked env value ex) FOOBARBAZ -> FOOB***
 func MaskEnvValue(s string) string {
 	if len(s) < 4 {

--- a/config/env_test.go
+++ b/config/env_test.go
@@ -1,8 +1,46 @@
 package config
 
 import (
+	"reflect"
 	"testing"
 )
+
+func TestMasked(t *testing.T) {
+	testCases := []struct {
+		name   string
+		env    Env
+		expect []string
+	}{
+		{
+			name:   "nil",
+			env:    nil,
+			expect: nil,
+		},
+		{
+			name:   "empty",
+			env:    Env{},
+			expect: nil,
+		},
+		{
+			name:   "short and long values",
+			env:    Env{"FOO=abc", "BAR=ABCDEFGH", "BAZ=12345=678"},
+			expect: []string{"FOO=abc", "BAR=ABCD***", "BAZ=1234***"},
+		},
+		{
+			name:   "empty value",
+			env:    Env{"FOO="},
+			expect: []string{"FOO="},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.env.Masked(); !reflect.DeepEqual(got, tc.expect) {
+				t.Fatalf("expect %v, actual %v", tc.expect, got)
+			}
+		})
+	}
+}
 
 func TestMaskEnvValue(t *testing.T) {
 	testCases := []struct {

--- a/metric/plugin.go
+++ b/metric/plugin.go
@@ -31,13 +31,7 @@ func NewPluginGenerator(p *config.MetricPlugin) Generator {
 // Generate generates metric values
 func (g *pluginGenerator) Generate(ctx context.Context) (Values, error) {
 	env := append(g.Env, pluginMetaEnvName+"=")
-	var masked_env []string
-	for _, v := range env {
-		key := strings.Split(v, "=")[0]
-		value := strings.Split(v, "=")[1]
-		masked_env = append(masked_env, key+"="+config.MaskEnvValue(value))
-	}
-	logger.Debugf("plugin %s command: %s env: %+v", g.Name, g.Command, masked_env)
+	logger.Debugf("plugin %s command: %s env: %+v", g.Name, g.Command, env.Masked())
 	stdout, stderr, _, err := cmdutil.RunCommand(ctx, g.Command, g.User, env, g.Timeout)
 
 	if stderr != "" {


### PR DESCRIPTION
The metric and check plugin generators each hand-rolled the same loop to
build a masked env slice for debug logging. Extracted it into a Masked
method on config.Env and reuse it from both. This also fixes a minor
linter issue about variable naming (no-underscore), and reduces the
allocation by `strings.Split`.
