### PR TITLE
[nit]Fixed the method for calculating memory usage.

### DIFF
--- a/platform/ecs/metric.go
+++ b/platform/ecs/metric.go
@@ -122,7 +122,18 @@ func calculateCPUMetrics(prev, curr *dockerTypes.StatsResponse, timeDelta time.D
 }
 
 func calculateMemoryMetrics(stats *dockerTypes.StatsResponse) float64 {
-	return float64(stats.MemoryStats.Usage - stats.MemoryStats.Stats["cache"])
+	// https://github.com/docker/cli/blob/bf6f62cc7cede71f83621b830d0c72e6fbaca9d6/docs/reference/commandline/container_stats.md
+	// cgroup v1
+	// The cache usage is defined as the value of total_inactive_file field in the memory.stat file on cgroup v1 hosts.
+	if v, isCgroup1 := stats.MemoryStats.Stats["total_inactive_file"]; isCgroup1 && v < stats.MemoryStats.Usage {
+		return float64(stats.MemoryStats.Usage - v)
+	}
+	// cgroup v2
+	// On cgroup v2 hosts, the cache usage is defined as the value of inactive_file field.
+	if v := stats.MemoryStats.Stats["inactive_file"]; v < stats.MemoryStats.Usage {
+		return float64(stats.MemoryStats.Usage - v)
+	}
+	return float64(stats.MemoryStats.Usage)
 }
 
 func calculateInterfaceMetrics(name string, prev, curr *dockerTypes.StatsResponse, timeDelta time.Duration, metricValues metric.Values) {

--- a/platform/ecs/metric_test.go
+++ b/platform/ecs/metric_test.go
@@ -58,7 +58,7 @@ func TestGenerateMetric(t *testing.T) {
 			metric.Values{
 				"container.cpu.mackerel-container-agent.usage":          0.0, // Result is 0 because use the same data.
 				"container.cpu.mackerel-container-agent.limit":          25.0,
-				"container.memory.mackerel-container-agent.usage":       1.2111872e+07,
+				"container.memory.mackerel-container-agent.usage":       5.3645312e+07,
 				"container.memory.mackerel-container-agent.limit":       134217728.0, // 128MiB
 				"interface.mackerel-container-agent-eth0.rxBytes.delta": 0,
 				"interface.mackerel-container-agent-eth0.txBytes.delta": 0,
@@ -69,7 +69,7 @@ func TestGenerateMetric(t *testing.T) {
 			metric.Values{
 				"container.cpu.mackerel-container-agent.usage":    0.0, // Result is 0 because use the same data.
 				"container.cpu.mackerel-container-agent.limit":    25.0,
-				"container.memory.mackerel-container-agent.usage": 1.048576e+06,
+				"container.memory.mackerel-container-agent.usage": 3.084288e+06,
 				"container.memory.mackerel-container-agent.limit": 134217728.0, // 128MiB
 			},
 		},
@@ -80,10 +80,10 @@ func TestGenerateMetric(t *testing.T) {
 				"container.cpu.mackerel-container-agent.limit":    25.0,
 				"container.cpu._internal_ecs_pause.usage":         0.0, // Result is 0 because use the same data.
 				"container.cpu._internal_ecs_pause.limit":         25.0,
-				"container.memory.mackerel-container-agent.usage": 1.1567104e+07,
+				"container.memory.mackerel-container-agent.usage": 5.2441088e+07,
 				"container.memory.mackerel-container-agent.limit": 134217728.0, // 128MiB
 				"container.memory._internal_ecs_pause.limit":      2.68435456e+08,
-				"container.memory._internal_ecs_pause.usage":      573440,
+				"container.memory._internal_ecs_pause.usage":      581632,
 			},
 		},
 		{
@@ -93,10 +93,10 @@ func TestGenerateMetric(t *testing.T) {
 				"container.cpu.mackerel-container-agent.limit":    25.0,
 				"container.cpu._internal_ecs_pause.usage":         0.0, // Result is 0 because use the same data.
 				"container.cpu._internal_ecs_pause.limit":         25.0,
-				"container.memory.mackerel-container-agent.usage": 1.1567104e+07,
+				"container.memory.mackerel-container-agent.usage": 5.2441088e+07,
 				"container.memory.mackerel-container-agent.limit": 134217728.0, // 128MiB
 				"container.memory._internal_ecs_pause.limit":      2.68435456e+08,
-				"container.memory._internal_ecs_pause.usage":      573440,
+				"container.memory._internal_ecs_pause.usage":      581632,
 			},
 		},
 	}


### PR DESCRIPTION
related https://github.com/docker/cli/pull/2415
https://github.com/docker/cli/blob/bf6f62cc7cede71f83621b830d0c72e6fbaca9d6/docs/reference/commandline/container_stats.md

> The cache usage is defined as the value of total_inactive_file field in the memory.stat file on cgroup v1 hosts.
> On cgroup v2 hosts, the cache usage is defined as the value of inactive_file field.